### PR TITLE
adjust cmake policy to match version introduced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 cmake_minimum_required (VERSION 3.9)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.16.2)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
 # Use standard target names
 cmake_policy(SET CMP0078 NEW)
+endif()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.14)
 # Allows SWIG_MODULE_NAME to be set
 cmake_policy(SET CMP0086 NEW)
 endif()


### PR DESCRIPTION
I saw warnings in cmake 3.13.4 on Ubuntu