### PR TITLE
Missing checkSlewLimitPreamble

### DIFF
--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -4896,6 +4896,7 @@ Sta::checkSlew(const Pin *pin,
 	       float &limit,
 	       float &slack)
 {
+  checkSlewLimitPreamble();
   check_slew_limits_->checkSlew(pin, corner, min_max, check_clks,
 				corner1, rf, slew, limit, slack);
 }


### PR DESCRIPTION
Minor issue, missing **checkSlewLimitPreamble()** at **Sta::checkSlew(const Pin *pin,..)** causes Segfault if called before any other method that calls **checkSlewLimitPreamble();**