### PR TITLE
Fix minor compilation errors

### DIFF
--- a/app/Main.cc
+++ b/app/Main.cc
@@ -17,6 +17,7 @@
 #include "StaMain.hh"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <tcl.h>
 
 #include "StaConfig.hh"  // STA_VERSION

--- a/search/Power.cc
+++ b/search/Power.cc
@@ -1189,7 +1189,7 @@ PwrActivity::check()
   // Activities can get very small from multiplying probabilities
   // through deep chains of logic. Clip them to prevent floating
   // point anomalies.
-  if (abs(activity_) < min_activity)
+  if (fabs(activity_) < min_activity)
     activity_ = 0.0;
 }
 

--- a/util/Report.cc
+++ b/util/Report.cc
@@ -17,6 +17,7 @@
 #include "Report.hh"
 
 #include <algorithm> // min
+#include <cstdlib>
 
 #include "Error.hh"
 


### PR DESCRIPTION
Add includes for exit and status declarations.
Use fabs() instead of abs() for absolute value of an fp value