### PR TITLE
app/findCmd: handle singular arg

### DIFF
--- a/app/StaMain.cc
+++ b/app/StaMain.cc
@@ -55,6 +55,7 @@ findCmdLineFlag(int &argc,
       for (int j = i + 1; j < argc; j++, i++)
 	argv[i] = argv[j];
       argc--;
+      argv[argc] = 0;
       return true;
     }
   }
@@ -74,6 +75,7 @@ findCmdLineKey(int &argc,
       for (int j = i + 2; j < argc; j++, i++)
 	argv[i] = argv[j];
       argc -= 2;
+      argv[argc] = 0;
       return value;
     }
   }


### PR DESCRIPTION
Noticed as part of https://github.com/The-OpenROAD-Project/OpenROAD/pull/2389 that the `findCmd*` helpers don't seem to discard singular argument (i.e: when the flag is the only remaining argument).

This is not strictly necessary, since this information is also convoyed using `argc` but might be good for consistency (discard arguments both when it's the only one left and when there are others remaining).
