### PR TITLE
Fixes C++20 compilation error

### DIFF
--- a/include/sta/PathExpanded.hh
+++ b/include/sta/PathExpanded.hh
@@ -20,6 +20,7 @@
 #include "GraphClass.hh"
 #include "SearchClass.hh"
 #include "StaState.hh"
+#include "PathRef.hh"
 
 namespace sta {
 


### PR DESCRIPTION
avoids referring to std::vector<T> members when T is incomplete.

This is not legal according to the C++ standard, and causes build errors in particular in C++20 mode. More specifically the call to .size( ) on line 40 is illegal without this header being present.