### PR TITLE
Add -Wp,-D_GLIBCXX_ASSERTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,11 +505,12 @@ target_include_directories(OpenSTA
   ${CUDD_INCLUDE}
   )
 
+set(CXX_COMMON_FLAGS -Wall -Wextra -pedantic -Wcast-qual -Wredundant-decls -Wformat-security -Wp,-D_GLIBCXX_ASSERTIONS)
 target_compile_options(OpenSTA
   PRIVATE
-  $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra -pedantic -Wcast-qual -Wredundant-decls -Wformat-security>
-  $<$<CXX_COMPILER_ID:AppleClang>:-Wall -Wextra -pedantic -Wcast-qual -Wredundant-decls -Wformat-security -Wno-gnu-zero-variadic-macro-arguments>
-  $<$<CXX_COMPILER_ID:Clang>:-Wall -Wextra -pedantic -Wcast-qual -Wredundant-decls -Wformat-security -Wno-gnu-zero-variadic-macro-arguments>
+  $<$<CXX_COMPILER_ID:GNU>:${CXX_COMMON_FLAGS}>
+  $<$<CXX_COMPILER_ID:AppleClang>:${CXX_COMMON_FLAGS} -Wno-gnu-zero-variadic-macro-arguments>
+  $<$<CXX_COMPILER_ID:Clang>:${CXX_COMMON_FLAGS} -Wno-gnu-zero-variadic-macro-arguments>
   )
 
 # Disable compiler specific extensions like gnu++11.


### PR DESCRIPTION
This PR adds runtime boundaries checks via glibc.

See https://github.com/The-OpenROAD-Project/OpenROAD/issues/1764 for details.
Some short [notes about](https://www.spinics.net/lists/fedora-devel/msg257877.html) and [summary docs](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html) regarding this flag.


---

* Currently as of fbcc26374d (master) **all regresion tests pass** (unlike few weeks ago).
* Using **standalone** regular [builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/package/opensta/) having regression tests on ```test``` and ```example``` folder.
* Having it as **standalone library** (separate from openroad) means flags from OR's top CMake won't propagate.

These are the tests used for mentioned builds:
```
%check
export LD_LIBRARY_PATH=%{buildroot}%{_libdir}
pushd test
%{buildroot}%{_bindir}/sta -exit regression.tcl
popd
pushd examples
for t in $(ls *.tcl)
do
  %{buildroot}%{_bindir}/sta -exit $t
done
popd

```
---

Cc @jjcherry56 , @maliberty , please help with the review.


