### PR TITLE
Adopt DCO v1.1 and allow external contributions while preserving Parallax Software's ability to license OpenSTA under a proprietary license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Open STA Contribution Model
+
+OpenSTA is contribution is mediated by the [DCO v1.1](https://developercertificate.org/). 
+
+As such contributors are required to "sign-off" their commits with `git commit -s` command. 
+This signifies your agreement to the terms in the afermentioned DCO v1.1
+
+## History
+
+OpenSTA was originally open sourced by *Parallax Software* under the GPL v3.0 license. 
+*Parallax Software* is a small business that generously contributed its STA engine so
+that the open source hardware community could flourish. *Parallax Software* is still
+a thriving business that sells support and proprietary licenses to OpenSTA **(link here to
+find more info)**.
+
+As such OpenSTA has historically not allowed external contributors, because accepting a
+contribution under the GPL would prevent *Parallax Software* from selling proprietary 
+licenses.
+
+## Accepting External Contributions
+
+The DCO v1.1 allows contributors to choose a license if permitted by the upstream project.
+
+```
+under the same open source license (unless I am
+permitted to submit under a different license), as indicated
+in the file;
+```
+
+In order to allow open source contribution to this project as well as preserve the business
+needs of *Parallax Software* we ask that contributors license their contributions under 
+Apache 2.0. **Make no mistake OpenSTA remains firmly GPL v3.0, but will have some Apache 2.0
+code. Any use will need to comply with both licenses.**
+
+*Parallax Software* employees and officers will continue to be allowed to provide their contributions
+under GPL v3.0
+
+Contributions "signed-off" with `git commit -s` are agreeing to license their contributions
+under Apache 2.0 under the terms of DCO v1.1, but to ensure clarity we 
+ask contributors to acknowledge this document before PRs will be accepted from them.
+
+### Acknowledgements
+
+This acknowledgment is not a legal agreement.
+
+```
+Ethan Mahintorabi <ethanmoon@google.com>
+```
+


### PR DESCRIPTION
@jjcherry56 @tspyrou

Hi James,

Tom let me know that you wanted me to sign a CLA, but setting that up requires a bit more infrastructure than is currently available in the OpenSTA repo.

I think what I've proposed in the CONTRIBUTING.md is a good alternative. At a high level OpenSTA will adopt the DCO v1.1, and ask contributors to license their modifications under Apache 2.0. The core OpenSTA you provide will continue to be licensed under GPL v3.

It will allow you to continue to sell proprietary licenses to OpenSTA, and allow contributors to license you their modifications under Apache 2.0. The combined work will still be licensed under GPL v3. 

You will need to comply with the NOTICE requirements of the Apache 2.0 code i.e. providing the Apache 2.0 LICENSE to your customers.

Contributors will need to sign-off their commits with `git commit -s`, like OpenROAD, and as such we should add the [DCO bot](https://github.com/apps/dco) to this repo if you choose to adopt my plan.

I appreciate all you've done for the open source community, and I hope that we can work together more in the future under this new working model.