### PR TITLE
#RFC-Fixing recovery and removal checks control

### DIFF
--- a/search/Search.cc
+++ b/search/Search.cc
@@ -3205,7 +3205,7 @@ Search::isEndpoint(Vertex *vertex,
 	    && gated_clk_->isGatedClkEnable(vertex))
 	|| vertex->isConstrained()
 	|| sdc_->isPathDelayInternalEndpoint(pin)
-	|| !hasFanout(vertex, pred, graph_)
+	//|| !hasFanout(vertex, pred, graph_)
 	// Unconstrained paths at register clk pins.
 	|| (unconstrained_paths_
 	    && vertex->isRegClk()));


### PR DESCRIPTION
We can disable recovery and removal checks with 
```set sta_recovery_removal_checks_enabled 0```

However,
```!hasFanout(vertex, pred, graph_)```
blocks its effect. Commenting this out fixes the problem.