### PR TITLE
Optimize use of std::shared_ptr. 

### DIFF
--- a/include/sta/TableModel.hh
+++ b/include/sta/TableModel.hh
@@ -89,7 +89,7 @@ protected:
 		  float &slew,
 		  float &cap) const;
   void setIsScaled(bool is_scaled) override;
-  float axisValue(TableAxisPtr axis,
+  float axisValue(const TableAxisPtr& axis,
 		  float load_cap,
 		  float in_slew,
 		  float related_out_cap) const;
@@ -164,7 +164,7 @@ protected:
 		      float &axis_value1,
 		      float &axis_value2,
 		      float &axis_value3) const;
-  float axisValue(TableAxisPtr axis,
+  float axisValue(const TableAxisPtr& axis,
 		  float load_cap,
 		  float in_slew,
 		  float related_out_cap) const;
@@ -196,6 +196,9 @@ public:
   TableAxisPtr axis1() const;
   TableAxisPtr axis2() const;
   TableAxisPtr axis3() const;
+  const TableAxisPtr& readonly_axis1() const;
+  const TableAxisPtr& readonly_axis2() const;
+  const TableAxisPtr& readonly_axis3() const;
   void setIsScaled(bool is_scaled);
   float value(size_t index1,
               size_t index2,
@@ -248,6 +251,9 @@ public:
   virtual TableAxisPtr axis1() const { return nullptr; }
   virtual TableAxisPtr axis2() const { return nullptr; }
   virtual TableAxisPtr axis3() const { return nullptr; }
+  virtual const TableAxisPtr& readonly_axis1() const { return nullptr; }
+  virtual const TableAxisPtr& readonly_axis2() const { return nullptr; }
+  virtual const TableAxisPtr& readonly_axis3() const { return nullptr; }
   void setIsScaled(bool is_scaled);
   virtual float value(size_t axis_idx1,
                       size_t axis_idx2,
@@ -317,6 +323,7 @@ public:
   Table1 &operator= (Table1 &&table);
   int order() const override { return 1; }
   TableAxisPtr axis1() const override { return axis1_; }
+  const TableAxisPtr& readonly_axis1() const override { return axis1_; }
   float value(size_t axis_index1,
               size_t axis_index2,
               size_t axis_index3) const override;
@@ -363,6 +370,8 @@ public:
   int order() const override { return 2; }
   TableAxisPtr axis1() const override { return axis1_; }
   TableAxisPtr axis2() const override { return axis2_; }
+  const TableAxisPtr& readonly_axis1() const override { return axis1_; }
+  const TableAxisPtr& readonly_axis2() const override { return axis2_; }
   float value(size_t axis_index1,
               size_t axis_index2,
               size_t axis_index3) const override;
@@ -409,6 +418,9 @@ public:
   TableAxisPtr axis1() const override { return axis1_; }
   TableAxisPtr axis2() const override { return axis2_; }
   TableAxisPtr axis3() const override { return axis3_; }
+  const TableAxisPtr& readonly_axis1() const override { return axis1_; }
+  const TableAxisPtr& readonly_axis2() const override { return axis2_; }
+  const TableAxisPtr& readonly_axis3() const override { return axis3_; }
   float value(size_t axis_index1,
               size_t axis_index2,
               size_t axis_index3) const override;

--- a/liberty/TableModel.cc
+++ b/liberty/TableModel.cc
@@ -225,24 +225,24 @@ GateTableModel::findAxisValues(const TableModel *model,
     axis_value3 = 0.0;
     break;
   case 1:
-    axis_value1 = axisValue(model->axis1(), in_slew, load_cap,
+    axis_value1 = axisValue(model->readonly_axis1(), in_slew, load_cap,
 			    related_out_cap);
     axis_value2 = 0.0;
     axis_value3 = 0.0;
     break;
   case 2:
-    axis_value1 = axisValue(model->axis1(), in_slew, load_cap,
+    axis_value1 = axisValue(model->readonly_axis1(), in_slew, load_cap,
 			    related_out_cap);
-    axis_value2 = axisValue(model->axis2(), in_slew, load_cap,
+    axis_value2 = axisValue(model->readonly_axis2(), in_slew, load_cap,
 			    related_out_cap);
     axis_value3 = 0.0;
     break;
   case 3:
-    axis_value1 = axisValue(model->axis1(), in_slew, load_cap,
+    axis_value1 = axisValue(model->readonly_axis1(), in_slew, load_cap,
 			    related_out_cap);
-    axis_value2 = axisValue(model->axis2(), in_slew, load_cap,
+    axis_value2 = axisValue(model->readonly_axis2(), in_slew, load_cap,
 			    related_out_cap);
-    axis_value3 = axisValue(model->axis3(), in_slew, load_cap,
+    axis_value3 = axisValue(model->readonly_axis3(), in_slew, load_cap,
 			    related_out_cap);
     break;
   default:
@@ -269,9 +269,9 @@ GateTableModel::maxCapSlew(float in_slew,
 			   float &slew,
 			   float &cap) const
 {
-  TableAxisPtr axis1 = slew_model_->axis1();
-  TableAxisPtr axis2 = slew_model_->axis2();
-  TableAxisPtr axis3 = slew_model_->axis3();
+  const TableAxisPtr& axis1 = slew_model_->readonly_axis1();
+  const TableAxisPtr& axis2 = slew_model_->readonly_axis2();
+  const TableAxisPtr& axis3 = slew_model_->readonly_axis3();
   if (axis1
       && axis1->variable() == TableAxisVariable::total_output_net_capacitance) {
     cap = axis1->axisValue(axis1->size() - 1);
@@ -298,7 +298,7 @@ GateTableModel::maxCapSlew(float in_slew,
 }
 
 float
-GateTableModel::axisValue(TableAxisPtr axis,
+GateTableModel::axisValue(const TableAxisPtr& axis,
 			  float in_slew,
 			  float load_cap,
 			  float related_out_cap) const
@@ -320,9 +320,9 @@ GateTableModel::axisValue(TableAxisPtr axis,
 bool
 GateTableModel::checkAxes(const TablePtr table)
 {
-  TableAxisPtr axis1 = table->axis1();
-  TableAxisPtr axis2 = table->axis2();
-  TableAxisPtr axis3 = table->axis3();
+  const TableAxisPtr& axis1 = table->readonly_axis1();
+  const TableAxisPtr& axis2 = table->readonly_axis2();
+  const TableAxisPtr& axis3 = table->readonly_axis3();
   bool axis_ok = true;
   if (axis1)
     axis_ok &= checkAxis(axis1);
@@ -369,9 +369,9 @@ ReceiverModel::setCapacitanceModel(TableModel *table_model,
 bool
 ReceiverModel::checkAxes(TablePtr table)
 {
-  TableAxisPtr axis1 = table->axis1();
-  TableAxisPtr axis2 = table->axis2();
-  TableAxisPtr axis3 = table->axis3();
+  const TableAxisPtr& axis1 = table->readonly_axis1();
+  const TableAxisPtr& axis2 = table->readonly_axis2();
+  const TableAxisPtr& axis3 = table->readonly_axis3();
   return (axis1 && axis1->variable() == TableAxisVariable::input_net_transition
           && axis2 == nullptr
           && axis3 == nullptr)
@@ -540,7 +540,7 @@ CheckTableModel::findAxisValues(float from_slew,
 }
 
 float
-CheckTableModel::axisValue(TableAxisPtr axis,
+CheckTableModel::axisValue(const TableAxisPtr& axis,
 			   float from_slew,
 			   float to_slew,
 			   float related_out_cap) const
@@ -561,9 +561,9 @@ CheckTableModel::axisValue(TableAxisPtr axis,
 bool
 CheckTableModel::checkAxes(const TablePtr table)
 {
-  TableAxisPtr axis1 = table->axis1();
-  TableAxisPtr axis2 = table->axis2();
-  TableAxisPtr axis3 = table->axis3();
+  const TableAxisPtr& axis1 = table->readonly_axis1();
+  const TableAxisPtr& axis2 = table->readonly_axis2();
+  const TableAxisPtr& axis3 = table->readonly_axis3();
   bool axis_ok = true;
   if (axis1)
     axis_ok &= checkAxis(axis1);
@@ -631,6 +631,24 @@ TableAxisPtr
 TableModel::axis3() const
 {
   return table_->axis3();
+}
+
+const TableAxisPtr& 
+TableModel::readonly_axis1() const
+{
+  return table_->readonly_axis1();
+}
+
+const TableAxisPtr& 
+TableModel::readonly_axis2() const
+{
+  return table_->readonly_axis2();
+}
+
+const TableAxisPtr& 
+TableModel::readonly_axis3() const
+{
+  return table_->readonly_axis3();
 }
 
 float
@@ -1608,9 +1626,9 @@ OutputWaveforms::~OutputWaveforms()
 bool
 OutputWaveforms::checkAxes(TableTemplate *tbl_template)
 {
-  TableAxisPtr axis1 = tbl_template->axis1();
-  TableAxisPtr axis2 = tbl_template->axis2();
-  TableAxisPtr axis3 = tbl_template->axis3();
+  const TableAxisPtr& axis1 = tbl_template->readonly_axis1();
+  const TableAxisPtr& axis2 = tbl_template->readonly_axis2();
+  const TableAxisPtr& axis3 = tbl_template->readonly_axis3();
   return (axis1 && axis1->variable() == TableAxisVariable::input_net_transition
           && axis2->variable() == TableAxisVariable::time
           && axis3 == nullptr)
@@ -1778,7 +1796,7 @@ OutputWaveforms::findVoltages(size_t wave_index,
   // i = C dv/dt
   FloatSeq volts;
   Table1 *currents = current_waveforms_[wave_index];
-  TableAxisPtr time_axis = currents->axis1();
+  const TableAxisPtr& time_axis = currents->readonly_axis1();
   float prev_time = time_axis->axisValue(0);
   float prev_current = currents->value(0);
   float voltage = 0.0;


### PR DESCRIPTION
This change speeds up the OpenRoad Gate Resizer tool by 35% for a circuit we care about. Passing a `std::shared_ptr` by  value (and subsequently destroying the copy) is not free because it requires an atomic update to the associated reference counter.

Bottom-up view before: 
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/5c066423-58f7-4a8b-92a6-e16776987d6c)

Bottom-up view after: 
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/cc2ed556-29dd-4244-9666-aac0a3832f0c)


Flame graph before:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/a68bd9ab-edc0-4f05-b5cf-c82fad67bc63)

Flame graph after:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/275434a9-a8df-40ca-8986-a2699283585f)

