### PR TITLE
Speed up findAxisIndex by 25%.

### DIFF
--- a/liberty/TableModel.cc
+++ b/liberty/TableModel.cc
@@ -1449,7 +1449,8 @@ size_t
 TableAxis::findAxisIndex(float value) const
 {
   int max = static_cast<int>(values_->size()) - 1;
-  if (value <= (*values_)[0] || max == 0)
+  if (max <= 0 || value <= (*values_)[0])
+    // Return 0 if value is too small or the table is empty.
     return 0;
   else if (value >= (*values_)[max])
     // Return max-1 for value too large so interpolation pts are index,index+1.
@@ -1458,12 +1459,22 @@ TableAxis::findAxisIndex(float value) const
     int lower = -1;
     int upper = max + 1;
     bool ascend = ((*values_)[max] >= (*values_)[0]);
-    while (upper - lower > 1) {
-      int mid = (upper + lower) >> 1;
-      if ((value >= (*values_)[mid]) == ascend)
-	lower = mid;
-      else
-	upper = mid;
+    if (ascend) {
+      while (upper - lower > 1) {
+        int mid = (upper + lower) >> 1;
+        if (value >= (*values_)[mid])
+          lower = mid;
+        else
+          upper = mid;
+      }
+    } else {
+      while (upper - lower > 1) {
+        int mid = (upper + lower) >> 1;
+        if (value < (*values_)[mid])
+          lower = mid;
+        else
+          upper = mid;
+      }
     }
     return lower;
   }


### PR DESCRIPTION
This is done by hoisting the instructions to handle ascending vs. non-ascending out of the inner loop in the bisection search. In our application, this function is the largest contributor to total runtime.

This change also fixes a latent bug potentially invoking undefined behavior (accessing element with index -1) if the table is empty.

Pivoted flame graph before:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/836f5dbc-f822-4cf5-8ca1-96a6afc414d0)

Pivoted flame graph after:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/adf07522-4e61-4940-b6e5-c7c5e6c6cccf)
