### PR TITLE
Speed up approximate exponential function by  2.1x

### DIFF
--- a/dcalc/DmpCeff.cc
+++ b/dcalc/DmpCeff.cc
@@ -1775,7 +1775,7 @@ exp2(double x)
   // However, for x > 709.78271, exp(x) can no longer be represented as a double and exp(x) overflows
   // to +Inf anyway, so we move the overflow point down to 707.703272. For the same reason, we return
   // zero for arguments less than -707.703272.
-  constexpr double kHuge =  707.703272;
+  constexpr double kHuge = 707.703272;
   if (x > kHuge) {
     return std::numeric_limits<double>::infinity();
   } else if (x < -kHuge) {

--- a/dcalc/DmpCeff.cc
+++ b/dcalc/DmpCeff.cc
@@ -1775,11 +1775,13 @@ exp2(double x)
     // exp(-12) = 6.1e-6
     return 0.0;
   else {
-    constexpr double kScale = 1048576 / M_LN2;
-    constexpr int kShift = 1072693248 - 60801;
-    union { double d; int64_t i;} e;
-    e.i = (static_cast<int>(kScale*x) + kShift) << 32;
-    return e.d;
+    constexpr int32_t kExpA = 1048576 / M_LN2;  // 2^20 / ln(2)
+    constexpr int32_t kExpB = 1072693248;  // 1023 * 2^20
+    constexpr int32_t kExpC = 60801;  // heuristic to minimize RMS error
+    int64_t exp_bits = static_cast<int64_t>(kExpA * x + (kExpB - kExpC)) << 32;
+    double exp_double;
+    std::memcpy(&exp_double, &exp_bits, sizeof(double));
+    return exp_double;
   }
 }
 


### PR DESCRIPTION
This change replaces the fast exponential approximation based on the limit exp(x) = lim_{n->inf} (1+x/n)^n, which uses 1 double division, 1 double addition and 12 double multiplications.  The new implementation uses [Shraudolph's  approximation](https://www.schraudolph.org/pubs/Schraudolph99.pdf), which uses 1 double multiplication, 1 double addition, and 1 integer shift. The Shraudolph approximation is accurate (maximum absolute error 2.98%) over a much larger interval than the old implementation. In fact, the 2.98% max error was measured on the interval `[-707.703272; 707.703272]`, which is almost the entire interval on which `exp(x)` doesn't overflow the IEEE `double` range: `[-709.78271; 709.78271]`

In comparison, the old approximation has zero correct bits when the absolute value of the argument exceeds ~88.

Pivoted flame graph before:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/511ed823-253a-4562-938d-8e1cff238201)

Pivoted flame graph after:
![image](https://github.com/The-OpenROAD-Project/OpenSTA/assets/16907534/402ba0ad-bdb7-48fe-8635-9bbf84ee586c)
