### PR TITLE
Speed up a loop in findCrpr

### DIFF
--- a/search/Crpr.hh
+++ b/search/Crpr.hh
@@ -56,7 +56,7 @@ public:
 			 int arrival_index);
 
 private:
-  PathVertex *clkPathPrev(const PathVertex *path,
+  void clkPathPrev(const PathVertex *path,
 			  PathVertex &tmp);
   Arrival otherMinMaxArrival(const PathVertex *path);
   void checkCrpr1(const Path *src_path,


### PR DESCRIPTION
This is done by:
* inlining a call of `clkPathPrev(Vertex *vertex, int arrival_index)`
* removing redundant conditions
* returning the result of `clkPathPrev(const PathVertex *path, PathVertex &tmp)` only by reference

This loop is repeated over 500 million times in case of black_parrot design. The changes mentioned above give ~3.5% performance gain on grt stage.
I compared the times of 10 runs of grt stage only:
|  Without my changes    |  With my changes  |
|:-----------|-------------------:|
| 11:55.64   | 11:32.40 |
| 11:53.50   | 11:31.19 |
| 11:52.95   | 11:30.97 |
| 11:54.99   | 11:23.12 |
| 11:42.94   | 11:15.42 |
| 11:51.53   | 11:19.78 |
| 11:54.56   | 11:31.04 |
| 11:51.72   | 11:34.29 |
| 11:56.03   | 11:31.32 |
| 11:51.72   | 11:25.89 |
