### PR TITLE
Replace construction of PathVertex objects with updating existing structure in Crpr computation

### DIFF
--- a/search/Crpr.cc
+++ b/search/Crpr.cc
@@ -55,23 +55,26 @@ CheckCrpr::clkPathPrev(const PathVertex *path,
   int arrival_index;
   bool exists;
   path->arrivalIndex(arrival_index, exists);
-  tmp = clkPathPrev(vertex, arrival_index);
-  if (tmp.isNull())
-    return nullptr;
-  else
-    return &tmp;
+  clkPathPrev(vertex, arrival_index, tmp);
+  return tmp.isNull() ? nullptr : &tmp;
 }
 
-PathVertex
+void
 CheckCrpr::clkPathPrev(Vertex *vertex,
-		       int arrival_index)
+		       int arrival_index, PathVertex &tmp)
 {
   PathVertexRep *prevs = graph_->prevPaths(vertex);
-  if (prevs)
-    return PathVertex(prevs[arrival_index], this);
+  if (prevs) {
+    const PathVertexRep &vertex_path_rep = prevs[arrival_index];
+    tmp.init(
+      vertex_path_rep.vertex(this),
+      vertex_path_rep.tag(this),
+      this
+    );
+  }
   else {
     criticalError(248, "missing prev paths");
-    return PathVertex();
+    tmp.init();
   }
 }
 

--- a/search/Crpr.cc
+++ b/search/Crpr.cc
@@ -249,14 +249,19 @@ CheckCrpr::findCrpr(const PathVertex *src_clk_path,
   // src_clk_path and tgt_clk_path are now in the same (gen)clk src path.
   // Use the vertex levels to back up the deeper path to see if they
   // overlap.
+  Level src_level = src_clk_path2->vertex(this)->level();
+  Level tgt_level = tgt_clk_path2->vertex(this)->level();
   while (src_clk_path2 && tgt_clk_path2
 	 && src_clk_path2->pin(this) != tgt_clk_path2->pin(this)) {
-    Level src_level = src_clk_path2->vertex(this)->level();
-    Level tgt_level = tgt_clk_path2->vertex(this)->level();
-    if (src_level >= tgt_level)
+    int diff = src_level - tgt_level;
+    if (diff >= 0) {
       src_clk_path2 = clkPathPrev(src_clk_path2, tmp1);
-    if (tgt_level >= src_level)
+      src_level = src_clk_path2->vertex(this)->level();
+    }
+    if (diff <= 0) {
       tgt_clk_path2 = clkPathPrev(tgt_clk_path2, tmp2);
+      tgt_level = tgt_clk_path2->vertex(this)->level();
+    }
   }
   if (src_clk_path2 && tgt_clk_path2
       && (src_clk_path2->transition(this) == tgt_clk_path2->transition(this)

--- a/search/Crpr.hh
+++ b/search/Crpr.hh
@@ -52,8 +52,8 @@ public:
   // Previous clk path when crpr is enabled.
   PathVertex clkPathPrev(const PathVertex *path);
   // For Search::reportArrivals.
-  PathVertex clkPathPrev(Vertex *vertex,
-			 int arrival_index);
+  void clkPathPrev(Vertex *vertex,
+			 int arrival_index, PathVertex &tmp);
 
 private:
   PathVertex *clkPathPrev(const PathVertex *path,

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -2726,6 +2726,7 @@ Search::reportArrivals(Vertex *vertex) const
   if (tag_group) {
     report_->reportLine("Group %u", tag_group->index());
     ArrivalMap::Iterator arrival_iter(tag_group->arrivalMap());
+    PathVertex prev;
     while (arrival_iter.hasNext()) {
       Tag *tag;
       int arrival_index;
@@ -2739,7 +2740,7 @@ Search::reportArrivals(Vertex *vertex) const
       const char *clk_prev = "";
       if (report_clk_prev
 	  && tag_group->hasClkTag()) {
-	PathVertex prev = check_crpr_->clkPathPrev(vertex, arrival_index);
+	check_crpr_->clkPathPrev(vertex, arrival_index, prev);
         if (!prev.isNull())
           clk_prev = prev.name(this);
       }


### PR DESCRIPTION
This PR:

* Modifies `clkPathPrev` so that instead of calling `PathVertex` constructor to create temporary object it updates the existing object passed by reference
* Updates vertex levels in `findCrpr` only when necessary.

The results of this modification for Ariane design look as follows (for cts and grt steps, 10 runs):

|master cts|PR cts|master grt|PR grt|
|----------|------|----------|------|
|10:23     |11:11 |9:45      |10:25 |
|11:54     |10:57 |10:59     |10:32 |
|11:44     |10:49 |11:01     |10:52 |
|11:17     |11:05 |11:18     |10:24 |
|11:45     |12:36 |10:48     |12:54 |
|11:35     |10:08 |10:55     |9:37  |
|11:38     |10:03 |10:44     |9:37  |
|11:31     |10:03 |10:09     |9:35  |
|10:25     |10:02 |9:48      |9:39  |
|10:25     |10:02 |9:50      |9:38  |

This PR could be potentially combined with https://github.com/The-OpenROAD-Project/OpenSTA/pull/211, both affect neighboring parts of code.