### PR TITLE
Optimize BFS search

### DIFF
--- a/graph/Graph.cc
+++ b/graph/Graph.cc
@@ -1286,16 +1286,6 @@ Vertex::bfsInQueue(BfsIndex index) const
   return (bfs_in_queue_ >> unsigned(index)) & 1;
 }
 
-void
-Vertex::setBfsInQueue(BfsIndex index,
-		      bool value)
-{
-  if (value)
-    bfs_in_queue_ |= 1 << int(index);
-  else
-    bfs_in_queue_ &= ~(1 << int(index));
-}
-
 ////////////////////////////////////////////////////////////////
 //
 // Edge

--- a/include/sta/Graph.hh
+++ b/include/sta/Graph.hh
@@ -322,7 +322,12 @@ public:
   bool isConstrained() const { return is_constrained_; }
   void setIsConstrained(bool constrained);
   bool bfsInQueue(BfsIndex index) const;
-  void setBfsInQueue(BfsIndex index, bool value);
+  void setBfsInQueue(BfsIndex index) {
+      bfs_in_queue_ |=  (1 << int(index));
+  }
+  void clrBfsInQueue(BfsIndex index) {
+      bfs_in_queue_ &= ~(1 << int(index));
+  }
   bool isRegClk() const { return is_reg_clk_; }
   bool crprPathPruningDisabled() const { return crpr_path_pruning_disabled_;}
   void setCrprPathPruningDisabled(bool disabled);

--- a/include/sta/SearchClass.hh
+++ b/include/sta/SearchClass.hh
@@ -111,7 +111,7 @@ typedef StringSet PathGroupNameSet;
 typedef Vector<PathEnd*> PathEndSeq;
 typedef Vector<Arrival> ArrivalSeq;
 typedef Map<Vertex*, int> VertexPathCountMap;
-typedef UnorderedMap<Tag*, int, TagMatchHash, TagMatchEqual> ArrivalMap;
+typedef Map<Tag*, int, TagMatchLess> ArrivalMap;
 typedef Vector<PathVertex> PathVertexSeq;
 typedef Vector<Slack> SlackSeq;
 typedef Delay Crpr;

--- a/search/Bfs.cc
+++ b/search/Bfs.cc
@@ -71,8 +71,7 @@ BfsIterator::clear()
   while (levelLessOrEqual(level, last_level_)) {
     VertexSeq &level_vertices = queue_[level];
     for (auto vertex : level_vertices) {
-      if (vertex)
-	vertex->setBfsInQueue(bfs_index_, false);
+      if (vertex) vertex->clrBfsInQueue(bfs_index_);
     }
     level_vertices.clear();
     incrLevel(level);
@@ -102,8 +101,7 @@ BfsIterator::deleteEntries(Level level)
 {
   VertexSeq &level_vertices = queue_[level];
   for (auto vertex : level_vertices) {
-    if (vertex)
-      vertex->setBfsInQueue(bfs_index_, false);
+    if (vertex) vertex->clrBfsInQueue(bfs_index_);
   }
   level_vertices.clear();
 }
@@ -140,7 +138,7 @@ BfsIterator::visit(Level to_level,
 {
   int visit_count = 0;
   while (levelLessOrEqual(first_level_, last_level_)
-	 && levelLessOrEqual(first_level_, to_level)) {
+        && levelLessOrEqual(first_level_, to_level)) {
     VertexSeq &level_vertices = queue_[first_level_];
     incrLevel(first_level_);
     // Note that ArrivalVisitor::enqueueRefPinInputDelays may enqueue
@@ -149,12 +147,11 @@ BfsIterator::visit(Level to_level,
       Vertex *vertex = level_vertices.back();
       level_vertices.pop_back();
       if (vertex) {
-        vertex->setBfsInQueue(bfs_index_, false);
+        vertex->clrBfsInQueue(bfs_index_);
         visitor->visit(vertex);
         visit_count++;
       }
     }
-    level_vertices.clear();
     visitor->levelFinished();
   }
   return visit_count;
@@ -182,7 +179,7 @@ BfsIterator::visitParallel(Level to_level,
           if (vertex_count < thread_count) {
             for (Vertex *vertex : level_vertices) {
               if (vertex) {
-                vertex->setBfsInQueue(bfs_index_, false);
+                vertex->clrBfsInQueue(bfs_index_);
                 visitor->visit(vertex);
               }
             }
@@ -197,7 +194,7 @@ BfsIterator::visitParallel(Level to_level,
                 for (size_t i = from; i < to; i++) {
                   Vertex *vertex = level_vertices[i];
                   if (vertex) {
-                    vertex->setBfsInQueue(bfs_index_, false);
+                    vertex->clrBfsInQueue(bfs_index_);
                     visitors[k]->visit(vertex);
                   }
                 }
@@ -237,7 +234,7 @@ BfsIterator::next()
   VertexSeq &level_vertices = queue_[first_level_];
   Vertex *vertex = level_vertices.back();
   level_vertices.pop_back();
-  vertex->setBfsInQueue(bfs_index_, false);
+  vertex->clrBfsInQueue(bfs_index_);
   return vertex;
 }
 
@@ -258,7 +255,7 @@ BfsIterator::enqueue(Vertex *vertex)
     Level level = vertex->level();
     UniqueLock lock(queue_lock_);
     if (!vertex->bfsInQueue(bfs_index_)) {
-      vertex->setBfsInQueue(bfs_index_, true);
+      vertex->setBfsInQueue(bfs_index_);
       queue_[level].push_back(vertex);
 
       if (levelLess(last_level_, level))
@@ -310,8 +307,8 @@ BfsIterator::remove(Vertex *vertex)
       && static_cast<Level>(queue_.size()) > level) {
     for (auto &v : queue_[level]) {
       if (v == vertex) {
-	v = nullptr;
-	vertex->setBfsInQueue(bfs_index_, false);
+        v = nullptr;
+        vertex->clrBfsInQueue(bfs_index_);
         break;
       }
     }

--- a/search/TagGroup.cc
+++ b/search/TagGroup.cc
@@ -124,9 +124,7 @@ TagGroupBldr::TagGroupBldr(bool match_crpr_clk_pin,
   default_arrival_count_(sta->corners()->count()
 			 * RiseFall::index_count
 			 * MinMax::index_count),
-  arrival_map_(default_arrival_count_,
-	       TagMatchHash(match_crpr_clk_pin, sta),
-	       TagMatchEqual(match_crpr_clk_pin, sta)),
+  arrival_map_(TagMatchLess(match_crpr_clk_pin, sta)),
   arrivals_(default_arrival_count_),
   prev_paths_(default_arrival_count_),
   has_clk_tag_(false),
@@ -259,9 +257,7 @@ TagGroupBldr::makeTagGroup(TagGroupIndex index,
 ArrivalMap *
 TagGroupBldr::makeArrivalMap(const StaState *sta)
 {
-  ArrivalMap *arrival_map = new ArrivalMap(arrival_map_.size(),
-					   TagMatchHash(true, sta),
-					   TagMatchEqual(true, sta));
+  ArrivalMap *arrival_map = new ArrivalMap(TagMatchLess(true, sta));
   int arrival_index = 0;
   ArrivalMap::Iterator arrival_iter(arrival_map_);
   while (arrival_iter.hasNext()) {

--- a/search/TagGroup.cc
+++ b/search/TagGroup.cc
@@ -72,20 +72,6 @@ TagGroup::arrivalMapHash(ArrivalMap *arrival_map)
   return hash;
 }
 
-bool
-TagGroup::hasTag(Tag *tag) const
-{
-  return arrival_map_->hasKey(tag);
-}
-
-void
-TagGroup::arrivalIndex(Tag *tag,
-		       int &arrival_index,
-		       bool &exists) const
-{
-  arrival_map_->findKey(tag, arrival_index, exists);
-}
-
 void
 TagGroup::report(const StaState *sta) const
 {

--- a/search/TagGroup.hh
+++ b/search/TagGroup.hh
@@ -53,11 +53,16 @@ public:
   bool hasLoopTag() const { return has_loop_tag_; }
   bool ownArrivalMap() const { return own_arrival_map_; }
   int arrivalCount() const { return arrival_map_->size(); }
-  void arrivalIndex(Tag *tag,
-		    int &arrival_index,
-		    bool &exists) const;
+
+  void arrivalIndex(Tag *tag, int &arrival_index, bool &exists) const {
+    arrival_map_->findKey(tag, arrival_index, exists);
+  }
+
+  bool hasTag(Tag *tag) const {
+    return arrival_map_->hasKey(tag);
+  }
+
   ArrivalMap *arrivalMap() const { return arrival_map_; }
-  bool hasTag(Tag *tag) const;
 
 protected:
   size_t arrivalMapHash(ArrivalMap *arrival_map);


### PR DESCRIPTION
This PR contains few optimizations related to BFS search:
 - `setBfsInQueue(BfsIndex index, bool value)` got replaced by two functions `setBfsInQueue(BfsIndex index)` and `clrBfsInQueue(BfsIndex index)`. This removes the need for checking the set/clear argument.
 - `Map` is used instead of `UnorderedMap` for `ArrivalMap`. Since `Map` orders keys searching is quicker.

Assessment of introduced changes was done by running OpenROAD-flow-scripts CTS stage (multiple runs) on BlackParrot design with nangate45 PDK locally on an Intel(R) i7-8700 CPU @ 3.20GHz machine. Prior to the modifications the stage took about **248.4 seconds** whereas with the modifications around **243.6 seconds**