### PR TITLE
Remove reduntant checks from iterators

### DIFF
--- a/include/sta/Map.hh
+++ b/include/sta/Map.hh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <map>
 #include <algorithm>
 
@@ -133,17 +134,19 @@ public:
   {
   public:
     Iterator() : container_(nullptr) {}
-    explicit Iterator(std::map<KEY, VALUE, CMP> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit Iterator(std::map<KEY, VALUE, CMP> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit Iterator(std::map<KEY, VALUE, CMP> *container)
+    { init(container); }
+    explicit Iterator(std::map<KEY, VALUE, CMP> &container)
+    { init(container); }
     void init(std::map<KEY, VALUE, CMP> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(std::map<KEY, VALUE, CMP> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin();}
+    bool hasNext() { return iter_ != container_->end(); }
     VALUE next() { return iter_++->second; }
     void next(KEY &key,
 	      VALUE &value)
@@ -159,17 +162,19 @@ public:
   {
   public:
     ConstIterator() : container_(nullptr) {}
-    explicit ConstIterator(const std::map<KEY, VALUE, CMP> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit ConstIterator(const std::map<KEY, VALUE, CMP> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit ConstIterator(const std::map<KEY, VALUE, CMP> *container)
+    { init(container); }
+    explicit ConstIterator(const std::map<KEY, VALUE, CMP> &container)
+    { init(container); }
     void init(const std::map<KEY, VALUE, CMP> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(const std::map<KEY, VALUE, CMP> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin(); }
+    bool hasNext() { return iter_ != container_->end(); }
     VALUE next() { return iter_++->second; }
     void next(KEY &key,
 	      VALUE &value)

--- a/include/sta/UnorderedMap.hh
+++ b/include/sta/UnorderedMap.hh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <unordered_map>
 #include <algorithm>
 
@@ -143,17 +144,19 @@ public:
   {
   public:
     Iterator() : container_(nullptr) {}
-    explicit Iterator(std::unordered_map<KEY,VALUE,HASH,EQUAL> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit Iterator(std::unordered_map<KEY,VALUE,HASH,EQUAL> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit Iterator(std::unordered_map<KEY,VALUE,HASH,EQUAL> *container)
+    { init(container); }
+    explicit Iterator(std::unordered_map<KEY,VALUE,HASH,EQUAL> &container)
+    { init(container); }
     void init(std::unordered_map<KEY,VALUE,HASH,EQUAL> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(std::unordered_map<KEY,VALUE,HASH,EQUAL> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin();}
+    bool hasNext() { return iter_ != container_->end(); }
     VALUE next() { return iter_++->second; }
     void next(KEY &key,
 	      VALUE &value)
@@ -169,17 +172,19 @@ public:
   {
   public:
     ConstIterator() : container_(nullptr) {}
-    explicit ConstIterator(const std::unordered_map<KEY,VALUE,HASH,EQUAL> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit ConstIterator(const std::unordered_map<KEY,VALUE,HASH,EQUAL> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit ConstIterator(const std::unordered_map<KEY,VALUE,HASH,EQUAL> *container)
+    { init(container); }
+    explicit ConstIterator(const std::unordered_map<KEY,VALUE,HASH,EQUAL> &container)
+    { init(container); }
     void init(const std::unordered_map<KEY,VALUE,HASH,EQUAL> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(const std::unordered_map<KEY,VALUE,HASH,EQUAL> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin(); }
+    bool hasNext() { return iter_ != container_->end(); }
     VALUE next() { return iter_++->second; }
     void next(KEY &key,
 	      VALUE &value)

--- a/include/sta/UnorderedSet.hh
+++ b/include/sta/UnorderedSet.hh
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <unordered_set>
 #include <algorithm>
 
@@ -85,17 +86,19 @@ public:
   {
   public:
     Iterator() : container_(nullptr) {}
-    explicit Iterator(std::unordered_set<KEY,HASH,EQUAL> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit Iterator(std::unordered_set<KEY,HASH,EQUAL> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit Iterator(std::unordered_set<KEY,HASH,EQUAL> *container)
+    { init(container); }
+    explicit Iterator(std::unordered_set<KEY,HASH,EQUAL> &container)
+    { init(container); }
     void init(std::unordered_set<KEY,HASH,EQUAL> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(std::unordered_set<KEY,HASH,EQUAL> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin();}
+    bool hasNext() { return iter_ != container_->end(); }
     KEY next() { return *iter_++; }
     std::unordered_set<KEY,HASH,EQUAL> *container() { return container_; }
 
@@ -108,17 +111,19 @@ public:
   {
   public:
     ConstIterator() : container_(nullptr) {}
-    explicit ConstIterator(const std::unordered_set<KEY,HASH,EQUAL> *container) :
-      container_(container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
-    explicit ConstIterator(const std::unordered_set<KEY,HASH,EQUAL> &container) :
-      container_(&container)
-    { if (container_ != nullptr) iter_ = container_->begin(); }
+    explicit ConstIterator(const std::unordered_set<KEY,HASH,EQUAL> *container)
+    { init(container); }
+    explicit ConstIterator(const std::unordered_set<KEY,HASH,EQUAL> &container)
+    { init(container); }
     void init(const std::unordered_set<KEY,HASH,EQUAL> *container)
-    { container_ = container; if (container_ != nullptr) iter_=container_->begin();}
+    {
+      assert(container != nullptr);
+      container_ = container;
+      iter_ = container_->begin();
+    }
     void init(const std::unordered_set<KEY,HASH,EQUAL> &container)
-    { container_ = &container; if (container_ != nullptr) iter_=container_->begin();}
-    bool hasNext() { return container_ != nullptr && iter_ != container_->end(); }
+    { container_ = &container; iter_ = container_->begin();}
+    bool hasNext() { return iter_ != container_->end(); }
     KEY next() { return iter_++->second; }
     const std::unordered_set<KEY,HASH,EQUAL> *container() { return container_; }
 


### PR DESCRIPTION
Checking if `container_` is not null isn't necessary after the iterator is initialized. This PR removes these checks from `hasNext` methods of iterators of Map, UnorderedMap, UnorderedSet. It also refactors a little.
I measured the performance gain on grt phase on black_parrot design:
|  Without my changes    |  With my changes  |
|:-----------|-------------------:|
| 9:38.70 | 9:31.69
| 9:38.91 | 9:31.36
| 9:38.23 | 9:32.53
| 9:38.00 | 9:30.78
| 9:30.53 | 9:35.83
| 9:22.26 | 9:27.77
| 9:23.32 | 9:13.49
| 9:20.93 | 9:13.94
| 9:20.02 | 9:13.02
| 9:21.25 | 9:13.78

The average gain is slightly less than 1%. It probably speeds up other phases too.

There are still such checks in Set and Vector. When I removed them, I got seg faults. I think that some iterators weren't initialized before the iteration. I haven't tried to fix that yet.