### PR TITLE
Optimize the order of conditions in conjunction in tagMatch function

### DIFF
--- a/search/Tag.cc
+++ b/search/Tag.cc
@@ -403,15 +403,15 @@ tagMatch(const Tag *tag1,
   const ClkInfo *clk_info1 = tag1->clkInfo();
   const ClkInfo *clk_info2 = tag2->clkInfo();
   return tag1 == tag2
-    || (clk_info1->clkEdge() == clk_info2->clkEdge()
+    || (tag1->pathAPIndex() == tag2->pathAPIndex()
 	&& tag1->rfIndex() == tag2->rfIndex()
-	&& tag1->pathAPIndex() == tag2->pathAPIndex()
-	&& tag1->isClock() == tag2->isClock()
-	&& tag1->isSegmentStart() == tag2->isSegmentStart()
-	&& clk_info1->isGenClkSrcPath() == clk_info2->isGenClkSrcPath()
 	&& (!match_crpr_clk_pin
 	    || !sta->sdc()->crprActive()
 	    || clk_info1->crprClkVertexId() == clk_info2->crprClkVertexId())
+	&& clk_info1->clkEdge() == clk_info2->clkEdge()
+	&& tag1->isClock() == tag2->isClock()
+	&& tag1->isSegmentStart() == tag2->isSegmentStart()
+	&& clk_info1->isGenClkSrcPath() == clk_info2->isGenClkSrcPath()
 	&& tagStateEqual(tag1, tag2));
 }
 


### PR DESCRIPTION
 As I measured on grt phase of black_parrot design, `tagMatch` function is called over 1.1 billion times (2.6 billion when https://github.com/The-OpenROAD-Project/OpenSTA/pull/216 is merged), so it is worth optimizing.
I sorted conditions in the conjunction by failing frequency. I also noticed that the last 4 of them always pass if all previous have passed, so maybe they aren't really needed.