### PR TITLE
Parallel `findClkSkew`

### DIFF
--- a/search/ClkSkew.cc
+++ b/search/ClkSkew.cc
@@ -18,9 +18,11 @@
 
 #include <cmath> // abs
 #include <algorithm>
+#include <stack>
 
 #include "Report.hh"
 #include "Debug.hh"
+#include "DispatchQueue.hh"
 #include "Units.hh"
 #include "TimingArc.hh"
 #include "Liberty.hh"
@@ -245,22 +247,44 @@ ClkSkews::findClkSkew(ConstClockSeq &clks,
   ConstClockSet clk_set;
   for (const Clock *clk : clks)
     clk_set.insert(clk);
+  const auto findClkSkew = [this, corner, setup_hold, &clk_set](Vertex *src_vertex, ClkSkewMap &skews) {
+    VertexOutEdgeIterator edge_iter(src_vertex, graph_);
+    while (edge_iter.hasNext()) {
+      Edge *edge = edge_iter.next();
+      if (edge->role()->genericRole() != TimingRole::regClkToQ()) continue;
+      Vertex *q_vertex = edge->to(graph_);
+      RiseFall *rf = edge->timingArcSet()->isRisingFallingEdge();
+      RiseFallBoth *src_rf = rf
+          ? rf->asRiseFallBoth()
+          : RiseFallBoth::riseFall();
+      findClkSkewFrom(src_vertex, q_vertex, src_rf, clk_set, corner, setup_hold, skews);
+    }
+  };
 
-  for (Vertex *src_vertex : *graph_->regClkVertices()) {
-    if (hasClkPaths(src_vertex, clk_set)) {
-      VertexOutEdgeIterator edge_iter(src_vertex, graph_);
-      while (edge_iter.hasNext()) {
-	Edge *edge = edge_iter.next();
-	if (edge->role()->genericRole() == TimingRole::regClkToQ()) {
-	  Vertex *q_vertex = edge->to(graph_);
-	  const RiseFall *rf = edge->timingArcSet()->isRisingFallingEdge();
-	  const RiseFallBoth *src_rf = rf
-	    ? rf->asRiseFallBoth()
-	    : RiseFallBoth::riseFall();
-	  findClkSkewFrom(src_vertex, q_vertex, src_rf, clk_set,
-			  corner, setup_hold, skews);
-	}
+  if (threadCount() > 1) {
+    std::vector<ClkSkewMap> partial_skews(thread_count_, skews);
+    for (Vertex *src_vertex : *graph_->regClkVertices()) {
+      if (!hasClkPaths(src_vertex, clk_set)) continue;
+      dispatch_queue_->dispatch([findClkSkew, src_vertex, &partial_skews](int i) {
+        findClkSkew(src_vertex, partial_skews[i]);
+      });
+    }
+    dispatch_queue_->finishTasks();
+    for (size_t i = 0; i < partial_skews.size(); i++) {
+      for (auto [clk, partial_skew] : partial_skews[i]) {
+        auto ins = skews.insert(std::make_pair(clk, partial_skew));
+        if (ins.second) continue;
+        ClkSkew &final_skew = ins.first->second;
+        if (abs(partial_skew.skew()) > abs(final_skew.skew())) {
+          final_skew = partial_skew;
+        }
       }
+    }
+  }
+  else {
+    for (Vertex *src_vertex : *graph_->regClkVertices()) {
+      if (!hasClkPaths(src_vertex, clk_set)) continue;
+      findClkSkew(src_vertex, skews);
     }
   }
   return skews;
@@ -395,16 +419,46 @@ ClkSkews::findFanout(Vertex *from)
              from->name(sdc_network_));
   VertexSet endpoints(graph_);
   FanOutSrchPred pred(this);
-  BfsFwdIterator fanout_iter(BfsIndex::other, &pred, this);
-  fanout_iter.enqueue(from);
-  while (fanout_iter.hasNext()) {
-    Vertex *fanout = fanout_iter.next();
-    if (fanout->hasChecks()) {
-      debugPrint(debug_, "fanout", 1, " endpoint %s",
-                 fanout->name(sdc_network_));
-      endpoints.insert(fanout);
+  if (threadCount() > 1) {
+    // Get the fanout with depth-first search.
+    // Breadth-first would work too, but a stack is slightly faster than a queue.
+    // This is called from multiple threads, so BfsVisitor cannot be used, as it modifies vertex state.
+    thread_local static std::unordered_set<Vertex *> visited;
+    thread_local static std::stack<Vertex *, std::vector<Vertex *>> stack;
+    visited.clear();
+    stack.push(from);
+    visited.insert(from);
+    while (!stack.empty()) {
+      Vertex *fanout = stack.top();
+      stack.pop();
+      if (fanout->hasChecks()) {
+        debugPrint(debug_, "fanout", 1, " endpoint %s",
+                   fanout->name(sdc_network_));
+        endpoints.insert(fanout);
+      }
+      if (!pred.searchFrom(fanout)) continue;
+      VertexOutEdgeIterator edge_iter(fanout, graph_);
+      while (edge_iter.hasNext()) {
+        Edge *edge = edge_iter.next();
+        Vertex *to = edge->to(graph_);
+        if (pred.searchThru(edge) && pred.searchTo(to) && visited.insert(to).second) {
+          stack.push(to);
+        }
+      }
     }
-    fanout_iter.enqueueAdjacentVertices(fanout);
+  }
+  else {
+    BfsFwdIterator fanout_iter(BfsIndex::other, &pred, this);
+    fanout_iter.enqueue(from);
+    while (fanout_iter.hasNext()) {
+      Vertex *fanout = fanout_iter.next();
+      if (fanout->hasChecks()) {
+        debugPrint(debug_, "fanout", 1, " endpoint %s",
+                   fanout->name(sdc_network_));
+        endpoints.insert(fanout);
+      }
+      fanout_iter.enqueueAdjacentVertices(fanout);
+    }
   }
   return endpoints;
 }


### PR DESCRIPTION
Runs `findClkSkew` in parallel.

`findClkSkew` basically retrieves the absolute maximum skew per clock.
We can do it in separate threads and then reduce over the partial results from each thread.

## Benchmarks

![Ibex](https://github.com/The-OpenROAD-Project/OpenSTA/assets/9216518/8cd7a8dc-b74f-4f9b-b69f-3235032559c5)
![BlackParrot](https://github.com/The-OpenROAD-Project/OpenSTA/assets/9216518/d93ec1ef-19f2-446a-a858-25d721d175cd)