### PR TITLE
Optimize insert operations following find operations

### DIFF
--- a/graph/Graph.cc
+++ b/graph/Graph.cc
@@ -983,14 +983,13 @@ Graph::setWidthCheckAnnotation(const Pin *pin,
 {
   if (width_check_annotations_ == nullptr)
     width_check_annotations_ = new WidthCheckAnnotations;
-  float *widths = width_check_annotations_->findKey(pin);
+  float *&widths = (*width_check_annotations_)[pin];
   if (widths == nullptr) {
     int width_count = RiseFall::index_count * ap_count_;
     widths = new float[width_count];
     // Use negative (illegal) width values to indicate unannotated checks.
     for (int i = 0; i < width_count; i++)
       widths[i] = -1;
-    (*width_check_annotations_)[pin] = widths;
   }
   int index = ap_index * RiseFall::index_count + rf->index();
   widths[index] = width;
@@ -1037,13 +1036,12 @@ Graph::setPeriodCheckAnnotation(const Pin *pin,
 {
   if (period_check_annotations_ == nullptr)
     period_check_annotations_ = new PeriodCheckAnnotations;
-  float *periods = period_check_annotations_->findKey(pin);
+  float *&periods = (*period_check_annotations_)[pin];
   if (periods == nullptr) {
     periods = new float[ap_count_];
     // Use negative (illegal) period values to indicate unannotated checks.
     for (int i = 0; i < ap_count_; i++)
       periods[i] = -1;
-    (*period_check_annotations_)[pin] = periods;
   }
   periods[ap_index] = period;
 }

--- a/liberty/EquivCells.cc
+++ b/liberty/EquivCells.cc
@@ -113,18 +113,17 @@ EquivCells::findEquivCells(const LibertyLibrary *library,
     LibertyCell *cell = cell_iter.next();
     if (!cell->dontUse()) {
       unsigned hash = hashCell(cell);
-      LibertyCellSeq *matches = hash_matches.findKey(hash);
+      LibertyCellSeq *&matches = hash_matches[hash];
       if (matches) {
 	LibertyCellSeq::Iterator match_iter(matches);
 	while (match_iter.hasNext()) {
 	  LibertyCell *match = match_iter.next();
 	  if (equivCells(match, cell)) {
-	    LibertyCellSeq *equivs = equiv_cells_.findKey(match);
+	    LibertyCellSeq *&equivs = equiv_cells_[match];
 	    if (equivs == nullptr) {
 	      equivs = new LibertyCellSeq;
 	      equivs->push_back(match);
 	      unique_equiv_cells_.push_back(match);
-	      equiv_cells_[match] = equivs;
 	    }
 	    equivs->push_back(cell);
 	    equiv_cells_[cell] = equivs;
@@ -135,7 +134,6 @@ EquivCells::findEquivCells(const LibertyLibrary *library,
       }
       else {
 	matches = new LibertyCellSeq;
-	hash_matches[hash] = matches;
 	matches->push_back(cell);
       }
     }

--- a/liberty/Liberty.cc
+++ b/liberty/Liberty.cc
@@ -1395,27 +1395,24 @@ LibertyCell::makeTimingArcPortMaps()
     LibertyPort *from = arc_set->from();
     LibertyPort *to = arc_set->to();
     LibertyPortPair port_pair(from, to);
-    TimingArcSetSeq *sets = port_timing_arc_set_map_.findKey(port_pair);
-    if (sets == nullptr) {
+    TimingArcSetSeq *&from_to_sets = port_timing_arc_set_map_[port_pair];
+    if (from_to_sets == nullptr) {
       // First arc set for from/to ports.
-      sets = new TimingArcSetSeq;
-      port_timing_arc_set_map_[port_pair] = sets;
+      from_to_sets = new TimingArcSetSeq;
     }
-    sets->push_back(arc_set);
+    from_to_sets->push_back(arc_set);
 
-    sets = timing_arc_set_from_map_.findKey(from);
-    if (sets == nullptr) {
-      sets = new TimingArcSetSeq;
-      timing_arc_set_from_map_[from] = sets;
+    TimingArcSetSeq *&from_sets = timing_arc_set_from_map_[from];
+    if (from_sets== nullptr) {
+      from_sets = new TimingArcSetSeq;
     }
-    sets->push_back(arc_set);
+    from_sets->push_back(arc_set);
 
-    sets = timing_arc_set_to_map_.findKey(to);
-    if (sets == nullptr) {
-      sets = new TimingArcSetSeq;
-      timing_arc_set_to_map_[to] = sets;
+    TimingArcSetSeq *&to_sets = timing_arc_set_to_map_[to];
+    if (to_sets == nullptr) {
+      to_sets = new TimingArcSetSeq;
     }
-    sets->push_back(arc_set);
+    to_sets->push_back(arc_set);
   }
 }
 

--- a/network/Network.cc
+++ b/network/Network.cc
@@ -1613,12 +1613,11 @@ Network::clearNetDrvrPinMap()
 PinSet *
 Network::drivers(const Net *net)
 {
-  PinSet *drvrs = net_drvr_pin_map_.findKey(net);
+  PinSet *&drvrs = net_drvr_pin_map_[net];
   if (drvrs == nullptr) {
     drvrs = new PinSet(this);
     FindDrvrPins visitor(drvrs, this);
     visitConnectedPins(net, visitor);
-    net_drvr_pin_map_[net] = drvrs;
   }
   return drvrs;
 }

--- a/search/MakeTimingModel.cc
+++ b/search/MakeTimingModel.cc
@@ -729,7 +729,7 @@ TableTemplate *
 MakeTimingModel::ensureTableTemplate(const TableTemplate *drvr_template,
                                      TableAxisPtr load_axis)
 {
-  TableTemplate *model_template = template_map_.findKey(drvr_template);
+  TableTemplate *&model_template = template_map_[drvr_template];
   if (model_template == nullptr) {
     string template_name = "template_";
     template_name += std::to_string(tbl_template_index_++);
@@ -737,7 +737,6 @@ MakeTimingModel::ensureTableTemplate(const TableTemplate *drvr_template,
     model_template = new TableTemplate(template_name.c_str());
     model_template->setAxis1(load_axis);
     library_->addTableTemplate(model_template, TableTemplateType::delay);
-    template_map_[drvr_template] = model_template;
   }
   return model_template;
 }

--- a/search/PathGroup.cc
+++ b/search/PathGroup.cc
@@ -651,10 +651,9 @@ void
 MakePathEndsAll::visitPathEnd(PathEnd *path_end,
 			      PathGroup *group)
 {
-  PathEndSeq *ends = ends_.findKey(group);
+  PathEndSeq *&ends = ends_[group];
   if (ends == nullptr) {
     ends = new PathEndSeq;
-    ends_[group] = ends;
   }
   ends->push_back(path_end->copy());
 }

--- a/search/VisitPathGroupVertices.cc
+++ b/search/VisitPathGroupVertices.cc
@@ -191,11 +191,10 @@ vertexPathSetMapInsertPath(VertexPathSetMap *matching_path_map,
 			   int arrival_index,
 			   const StaState *sta)
 {
-  PathVertexSet *matching_paths = matching_path_map->findKey(vertex);
+  PathVertexSet *&matching_paths = (*matching_path_map)[vertex];
   if (matching_paths == nullptr) {
     PathLess path_less(sta);
     matching_paths = new PathVertexSet(path_less);
-    (*matching_path_map)[vertex] = matching_paths;
   }
   PathVertex *vpath = new PathVertex(vertex, tag, arrival_index);
   matching_paths->insert(vpath);


### PR DESCRIPTION
Often scenario is that `insert` operation follows `find` operation if the element isn't found. In this case, looking for the element is performed twice. This can be optimized by using `[]` operator and getting a reference to the element that was just added if it hasn't existed.
I tested it on 10 runs of `black_parrot`. It saves a few seconds in cts and grt phases.
Master:
| stage                     | min time [min]   | avg time [min]   | med time [min]   | max time [min]   | sum time [min]   |
|:--------------------------|:-----------------|:-----------------|:-----------------|:-----------------|:-----------------|
| 4_1_cts.log               | 5:04             | 5:16             | 5:16             | 5:22             | 52:44            |
| 5_1_grt.log               | 11:07            | 11:18            | 11:17            | 11:31            | 113:03           |

My changes:
| stage                     | min time [min]   | avg time [min]   | med time [min]   | max time [min]   | sum time [min]   |
|:--------------------------|:-----------------|:-----------------|:-----------------|:-----------------|:-----------------|
| 4_1_cts.log               | 5:04             | 5:11             | 5:11             | 5:18             | 51:50            |
| 5_1_grt.log               | 10:57            | 11:12            | 11:16            | 11:20            | 112:04           |