### PR TITLE
Fewer locks in `DispatchQueue`

### DIFF
--- a/include/sta/DispatchQueue.hh
+++ b/include/sta/DispatchQueue.hh
@@ -25,10 +25,10 @@ public:
   ~DispatchQueue();
   void setThreadCount(size_t thread_count);
   // Dispatch and copy.
-  void dispatch(const fp_t& op);
+  void dispatch(const fp_t& op) { q_.push_back(op); }
   // Dispatch and move.
-  void dispatch(fp_t&& op);
-  void finishTasks();
+  void dispatch(fp_t&& op) { q_.push_back(std::move(op)); }
+  void runTasks();
 
   // Deleted operations
   DispatchQueue(const DispatchQueue& rhs) = delete;
@@ -42,9 +42,10 @@ private:
 
   std::mutex lock_;
   std::vector<std::thread> threads_;
-  std::queue<fp_t> q_;
+  std::vector<bool> pending_;
+  std::vector<fp_t> q_;
   std::condition_variable cv_;
-  std::atomic<size_t> pending_task_count_;
+  size_t pending_count_ = 0;
   bool quit_ = false;
 };
 

--- a/search/Bfs.cc
+++ b/search/Bfs.cc
@@ -204,7 +204,7 @@ BfsIterator::visitParallel(Level to_level,
               });
               from = to;
             }
-            dispatch_queue_->finishTasks();
+            dispatch_queue_->runTasks();
           }
 	  visitor->levelFinished();
 	  level_vertices.clear();

--- a/search/PathGroup.cc
+++ b/search/PathGroup.cc
@@ -908,7 +908,7 @@ PathGroups::makeGroupPathEnds(VertexSet *endpoints,
       dispatch_queue_->dispatch( [endpoint, &visitors](int i)
       { visitors[i].visit(endpoint); } );
     }
-    dispatch_queue_->finishTasks();
+    dispatch_queue_->runTasks();
   }
 }
 


### PR DESCRIPTION
`DispatchQueue` locks the underlying job queue on basically any operation.
The main thread locks the mutex when pushing a new job, the worker threads lock the mutex when popping a job off the queue. 
Thanks to this, jobs can be executed eagerly.
However, all the locking is one of the causes of OpenROAD scaling poorly on more than 4 threads.

This PR changes that behavior so that the jobs are run only after they're all in the queue.
This means we don't need to do any locking when pushing a new job.
Once all jobs are in the queue, we notify the worker threads, and each one works on a chunk of the queue.
The only locking that happens is for notifying threads that there is work available/there is work to be done.
The worker threads don't lock anything while iterating over the jobs.

Benchmark for global routing on BlackParrot (10 samples each):
![black_parrot_boxplot](https://github.com/The-OpenROAD-Project/OpenSTA/assets/9216518/4dbdecda-9960-4119-a3ca-7bfaab91dff0)

Global routing on Ibex (20 samples, sorry about the variance):
![ibex_boxplot](https://github.com/The-OpenROAD-Project/OpenSTA/assets/9216518/1a4d93df-79ca-420e-a012-c1b7d6e57424)