### PR TITLE
Thread safety fixes

### DIFF
--- a/graph/Graph.cc
+++ b/graph/Graph.cc
@@ -519,6 +519,7 @@ Graph::makeArrivals(Vertex *vertex,
 Arrival *
 Graph::arrivals(Vertex *vertex)
 {
+  UniqueLock lock(arrivals_lock_);
   return arrivals_.pointer(vertex->arrivals());
 }
 
@@ -552,6 +553,7 @@ Graph::makeRequireds(Vertex *vertex,
 Required *
 Graph::requireds(Vertex *vertex)
 {
+  UniqueLock lock(requireds_lock_);
   return requireds_.pointer(vertex->requireds());
 }
 
@@ -590,6 +592,7 @@ Graph::makePrevPaths(Vertex *vertex,
 PathVertexRep *
 Graph::prevPaths(Vertex *vertex) const
 {
+  UniqueLock lock(prev_paths_lock_);
   return prev_paths_.pointer(vertex->prevPaths());
 }
 
@@ -1280,20 +1283,31 @@ Vertex::setHasDownstreamClkPin(bool has_clk_pin)
   has_downstream_clk_pin_ = has_clk_pin;
 }
 
+#define IN_QUEUE(mask, index) (mask & (1 << unsigned(index)))
+#define SET_IN_QUEUE(mask, index) ((mask) |= (1 << unsigned(index)))
+#define CLEAR_IN_QUEUE(mask, index) ((mask) &= ~(1 << unsigned(index)))
+
 bool
 Vertex::bfsInQueue(BfsIndex index) const
 {
-  return (bfs_in_queue_ >> unsigned(index)) & 1;
+  return IN_QUEUE(bfs_in_queue_, index);
 }
 
-void
+bool
 Vertex::setBfsInQueue(BfsIndex index,
-		      bool value)
+                      bool value)
 {
-  if (value)
-    bfs_in_queue_ |= 1 << int(index);
-  else
-    bfs_in_queue_ &= ~(1 << int(index));
+  unsigned char expected = bfs_in_queue_;
+  unsigned char desired;
+  do {
+    if ((value && IN_QUEUE(expected, index)) || (!value && !IN_QUEUE(expected, index))) {
+      return false;
+    }
+    desired = expected;
+    SET_IN_QUEUE(value ? desired : expected, index);
+    CLEAR_IN_QUEUE(value ? expected : desired, index);
+  } while (!bfs_in_queue_.compare_exchange_weak(expected, desired));
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/include/sta/Graph.hh
+++ b/include/sta/Graph.hh
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <mutex>
+#include <atomic>
 
 #include "Iterator.hh"
 #include "Map.hh"
@@ -246,7 +247,7 @@ protected:
   RequiredsTable requireds_;
   std::mutex requireds_lock_;
   PrevPathsTable prev_paths_;
-  std::mutex prev_paths_lock_;
+  mutable std::mutex prev_paths_lock_;
   Vector<bool> arc_delay_annotated_;
   int slew_rf_count_;
   bool have_arc_delays_;
@@ -322,7 +323,7 @@ public:
   bool isConstrained() const { return is_constrained_; }
   void setIsConstrained(bool constrained);
   bool bfsInQueue(BfsIndex index) const;
-  void setBfsInQueue(BfsIndex index, bool value);
+  bool setBfsInQueue(BfsIndex index, bool value);
   bool isRegClk() const { return is_reg_clk_; }
   bool crprPathPruningDisabled() const { return crpr_path_pruning_disabled_;}
   void setCrprPathPruningDisabled(bool disabled);
@@ -352,9 +353,9 @@ protected:
   EdgeId out_edges_;		// Edges from this vertex.
 
   // 4 bytes
-  unsigned int tag_group_index_:tag_group_index_bits; // 24
+  unsigned int tag_group_index_;  // >= tag_group_index_bits (24)
   // Each bit corresponds to a different BFS queue.
-  unsigned int bfs_in_queue_:int(BfsIndex::bits); // 4
+  std::atomic<unsigned char> bfs_in_queue_; // >= BfsIndex::bits (4)
   unsigned int slew_annotated_:slew_annotated_bits;
 
   // 4 bytes (32 bits)

--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -584,7 +584,7 @@ protected:
   TagIndex tag_next_;
   // Holes in tags_ left by deleting filter tags.
   std::vector<TagIndex> tag_free_indices_;
-  std::mutex tag_lock_;
+  mutable std::mutex tag_lock_;
   TagGroupSet *tag_group_set_;
   TagGroup **tag_groups_;
   TagGroupIndex tag_group_next_;
@@ -592,7 +592,7 @@ protected:
   std::vector<TagIndex> tag_group_free_indices_;
   // Capacity of tag_groups_.
   TagGroupIndex tag_group_capacity_;
-  std::mutex tag_group_lock_;
+  mutable std::mutex tag_group_lock_;
   // Latches data outputs to queue on the next search pass.
   VertexSet *pending_latch_outputs_;
   std::mutex pending_latch_outputs_lock_;

--- a/search/Bfs.cc
+++ b/search/Bfs.cc
@@ -254,18 +254,15 @@ void
 BfsIterator::enqueue(Vertex *vertex)
 {
   debugPrint(debug_, "bfs", 2, "enqueue %s", vertex->name(sdc_network_));
-  if (!vertex->bfsInQueue(bfs_index_)) {
+    if (vertex->setBfsInQueue(bfs_index_, true)) {
     Level level = vertex->level();
-    UniqueLock lock(queue_lock_);
-    if (!vertex->bfsInQueue(bfs_index_)) {
-      vertex->setBfsInQueue(bfs_index_, true);
+      UniqueLock lock(queue_lock_);
       queue_[level].push_back(vertex);
 
       if (levelLess(last_level_, level))
 	last_level_ = level;
       if (levelLess(level, first_level_))
 	first_level_ = level;
-    }
   }
 }
 

--- a/search/PathGroup.cc
+++ b/search/PathGroup.cc
@@ -95,6 +95,7 @@ PathGroup::~PathGroup()
 bool
 PathGroup::savable(PathEnd *path_end)
 {
+  UniqueLock lock(lock_);
   bool savable = false;
   if (compare_slack_) {
     // Crpr increases the slack, so check the slack

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -2760,12 +2760,14 @@ Search::reportArrivals(Vertex *vertex) const
 TagGroup *
 Search::tagGroup(TagGroupIndex index) const
 {
+  UniqueLock lock(tag_group_lock_);
   return tag_groups_[index];
 }
 
 TagGroup *
 Search::tagGroup(const Vertex *vertex) const
 {
+  UniqueLock lock(tag_group_lock_);
   TagGroupIndex index = vertex->tagGroupIndex();
   if (index == tag_group_index_max)
     return nullptr;
@@ -2776,6 +2778,7 @@ Search::tagGroup(const Vertex *vertex) const
 TagGroupIndex
 Search::tagGroupCount() const
 {
+  UniqueLock lock(tag_group_lock_);
   return tag_group_set_->size();
 }
 
@@ -2830,12 +2833,14 @@ Search::reportArrivalCountHistogram() const
 Tag *
 Search::tag(TagIndex index) const
 {
+  UniqueLock lock(tag_lock_);
   return tags_[index];
 }
 
 TagIndex
 Search::tagCount() const
 {
+  UniqueLock lock(tag_lock_);
   return tag_set_->size();
 }
 


### PR DESCRIPTION
As was decided in a meeting, before introducing changes that improve multi-threaded scaling we are to improve thread safety. This PR adds fixes for the following data races:

* Accessing `tags_` and `tag_groups_` in `sta::Search` while they're [being reallocated](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/search/Search.cc#L2874-L2888) [in another thread](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/search/Search.cc#L2637-L2652). It's not enough to delay the swap, as reading from an array is two operations on x86 (load the pointer, then load the array element). The array may get swapped out and freed in between those.
* Accessing and modifying [bit fields](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/include/sta/Graph.hh#L355-L358) from multiple threads. It's not possible to write individual bits to RAM, the best you can do is read a byte, do a bit operation on it, and write it back. Moreover, compilers can (and do) read up to 8 bytes, do bit operations on that, and write the whole 8 bytes back. If between reading and writing a field we're not even accessing (seemingly) changes, then the write-back overwrites that change.
* Indexing and inserting in an `ObjectTable` or `ArrayTable` in `sta::Graph` from [multiple](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/graph/Graph.cc#L522) [threads](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/graph/Graph.cc#L513).
* A race between [`PathGroup::savable`](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/search/PathGroup.cc#L96) which accesses `PathEnd`s and [`PathGroup::prune()`](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/search/PathGroup.cc#L132) which deletes `PathEnd`s.

These changes incur a significant slowdown (about 25%).

Note that these are only the races found by ThreadSanitizer, not necessarily all of them.