### PR TITLE
Guarded insertion into filtered_arrivals_ in sta::Search

### DIFF
--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -606,6 +606,7 @@ protected:
   ExceptionFrom *filter_from_;
   ExceptionTo *filter_to_;
   VertexSet *filtered_arrivals_;
+  std::mutex filtered_arrivals_mutex_;
   bool found_downstream_clk_pins_;
   PathGroups *path_groups_;
   VisitPathEnds *visit_path_ends_;

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -2686,8 +2686,10 @@ Search::setVertexArrivals(Vertex *vertex,
       }
       tag_bldr->copyArrivals(tag_group, prev_arrivals, prev_paths);
       vertex->setTagGroupIndex(tag_group->index());
-      if (tag_group->hasFilterTag())
+      if (tag_group->hasFilterTag()) {
+        std::lock_guard<std::mutex> guard(this->filtered_arrivals_mutex_);
         filtered_arrivals_->insert(vertex);
+      }
 
       if (has_requireds) {
 	requiredInvalid(vertex);
@@ -2712,8 +2714,10 @@ Search::setVertexArrivals(Vertex *vertex,
       tag_bldr->copyArrivals(tag_group, arrivals, prev_paths);
 
       vertex->setTagGroupIndex(tag_group->index());
-      if (tag_group->hasFilterTag())
+      if (tag_group->hasFilterTag()) {
+        std::lock_guard<std::mutex> guard(this->filtered_arrivals_mutex_);
         filtered_arrivals_->insert(vertex);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes a crash occurring when multiple threads (in testing 4+ threads resulted in a high chance of this crash happening) concurrently wrote to `filtered_arrivals_` in `Search::setVertexArrivals`. An example stack trace of the crash is:
```

 0# 0x000058A238E94DE0 in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 1# 0x00007D00A3FC8D60 in /lib/x86_64-linux-gnu/libc.so.6
 2# sta::Vertex::objectIdx() const in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 3# sta::ObjectTable<sta::Vertex>::objectId(sta::Vertex const*) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 4# sta::Graph::id(sta::Vertex const*) const in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 5# sta::VertexIdLess::operator()(sta::Vertex const*, sta::Vertex const*) const in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 6# std::_Rb_tree<sta::Vertex*, sta::Vertex*, std::_Identity<sta::Vertex*>, sta::VertexIdLess, std::allocator<sta::Vertex*> >::_M_get_insert_unique_pos(sta::Vertex* const&) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 7# std::pair<std::_Rb_tree_iterator<sta::Vertex*>, bool> std::_Rb_tree<sta::Vertex*, sta::Vertex*, std::_Identity<sta::Vertex*>, sta::VertexIdLess, std::allocator<sta::Vertex*> >::_M_insert_unique<sta::Vertex* const&>(sta::Vertex* const&) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 8# std::set<sta::Vertex*, sta::VertexIdLess, std::allocator<sta::Vertex*> >::insert(sta::Vertex* const&) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 9# sta::Search::setVertexArrivals(sta::Vertex*, sta::TagGroupBldr*) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
10# sta::ArrivalVisitor::visit(sta::Vertex*) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
11# 0x000058A2393603A0 in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
12# 0x000058A2393618D2 in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
13# 0x000058A2393617B4 in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
14# 0x000058A239361603 in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
15# std::function<void (int)>::operator()(int) const in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
16# sta::DispatchQueue::dispatch_thread_handler(unsigned long) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
17# void std::__invoke_impl<void, void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long>(std::__invoke_memfun_deref, void (sta::DispatchQueue::*&&)(unsigned long), sta::DispatchQueue*&&, unsigned long&&) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
18# std::__invoke_result<void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long>::type std::__invoke<void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long>(void (sta::DispatchQueue::*&&)(unsigned long), sta::DispatchQueue*&&, unsigned long&&) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
19# void std::thread::_Invoker<std::tuple<void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
20# std::thread::_Invoker<std::tuple<void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long> >::operator()() in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
21# std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (sta::DispatchQueue::*)(unsigned long), sta::DispatchQueue*, unsigned long> > >::_M_run() in /data/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
22# 0x00007D00A4376ED0 in /usr/lib/x86_64-linux-gnu/libstdc++.so.6
23# 0x00007D00A69EAEA7 in /lib/x86_64-linux-gnu/libpthread.so.0
24# clone in /lib/x86_64-linux-gnu/libc.so.6
```

The insertions have been guarded with a mutex to prevent concurrent writing