### PR TITLE
Updated formatting to fix ORFS TOC doc issue; fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# This is effecively a fork of [parallaxsw/OpenSTA](https://github.com/parallaxsw/OpenSTA).  All issues and PRs should be filed there.
+# Static Timing Analysis
+
+This is effectively a fork of [parallaxsw/OpenSTA](https://github.com/parallaxsw/OpenSTA).  All issues and PRs should be filed there.
 
 # Parallax Static Timing Analyzer
 


### PR DESCRIPTION
Fixed issue where disclaimer was being added to the TOC in the ORFS docs. Fixed typo.