### PR TITLE
Change memcpy to memmove

### DIFF
--- a/util/gzstream.hh
+++ b/util/gzstream.hh
@@ -117,7 +117,7 @@ public:
         int n_putback = gptr() - eback();
         if ( n_putback > 4)
             n_putback = 4;
-        memcpy( buffer + (4 - n_putback), gptr() - n_putback, n_putback);
+        memmove( buffer + (4 - n_putback), gptr() - n_putback, n_putback);
         
         int num = gzread( file, buffer+4, bufferSize-4);
         if (num <= 0) // ERROR or EOF


### PR DESCRIPTION
The arguments to the `memcpy` can overlap, use `memmove` instead