### PR TITLE
debug_DispatchQueue_ThreadPool_DeadLock

### DIFF
--- a/util/DispatchQueue.cc
+++ b/util/DispatchQueue.cc
@@ -42,11 +42,12 @@ void
 DispatchQueue::setThreadCount(size_t thread_count)
 {
   terminateThreads();
-
+  std::unique_lock<std::mutex> lock(lock_);
   threads_.resize(thread_count);
   for(size_t i = 0; i < thread_count; i++) {
     threads_[i] = std::thread(&DispatchQueue::dispatch_thread_handler, this, i);
   }
+  quit_ = false;
 }
 
 void


### PR DESCRIPTION
It is easy to reproduce this deadlock problem using the original code DispatchQueue.cc.

``` cpp
void s1(int thread) {
    std::cout << "Thread " << thread << " is sleeping for 10 seconds..."
        << std::endl;
    std::this_thread::sleep_for(std::chrono::seconds(10));
    std::cout << "Thread " << thread << " finished sleeping." << std::endl;
};

void testMt() {
    auto dqSptr = std::make_shared<sta::DispatchQueue>(10);
    for (int i{0}; i < 15; ++i) {
        if (i == 3) {
            dqSptr->setThreadCount(4);
        } else {
            dqSptr->dispatch(s1);
        }
    }
    std::cout << "all the tasks is dispatch\n";
    // It's likely that this is not 0
    std::cout << dqSptr->getPendingTaskCnt() << '\n';
    dqSptr->finishTasks();
    // If dqSptr->getPendingTaskCnt() is not 0, the following line won't be executed
    std::cout << " dqSptr->finishTasks(); is finished\n";
}


// My execution result
/*
Thread 0 is sleeping for 10 seconds...Thread 
Thread 3 is sleeping for 10 seconds...
2 is sleeping for 10 seconds...
Thread 0 finished sleeping.
Thread 3 finished sleeping.
Thread 2 finished sleeping.
all the tasks is dispatch
11

*/

```