### PR TITLE
Update Dockerfile.ubuntu22.04

### DIFF
--- a/Dockerfile.ubuntu22.04
+++ b/Dockerfile.ubuntu22.04
@@ -3,9 +3,8 @@ LABEL author="James Cherry"
 LABEL maintainer="James Cherry <cherry@parallaxsw.com>"
 
 # Install basics
-ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get install -y \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     wget \
     cmake \
     gcc \
@@ -15,6 +14,7 @@ RUN apt-get update && \
     swig \
     bison \
     flex \
+    libfl-dev \
     automake \
     autotools-dev
 


### PR DESCRIPTION
Contains two necessary changes to build successfully:

1. Move `DEBIAN_FRONTEND` to avoid timezone interaction. Current `ARG DEBIAN_FRONTEND` not seems to work.
2. Install `libfl-dev`, otherwise OpenSTA make will failed:

```
0.717 CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
0.717 Please set them or make sure they are set and tested correctly in the CMake files:
0.717 /OpenSTA/FLEX_INCLUDE_DIR
0.717    used as include directory in directory /OpenSTA
```