### PR TITLE
Avoid spurious clean slate levelization

### DIFF
--- a/search/Levelize.cc
+++ b/search/Levelize.cc
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <limits>
 
 #include "Report.hh"
 #include "Debug.hh"
@@ -51,7 +52,7 @@ Levelize::Levelize(StaState *sta) :
   levels_valid_(false),
   max_level_(0),
   level_space_(10),
-  max_incremental_level_(100),
+  max_incremental_level_(std::numeric_limits<size_t>::max()),
   roots_(graph_),
   relevelize_from_(graph_),
   observer_(nullptr)


### PR DESCRIPTION
Disable a newly added trigger of clean slate levelization breaking resizer's assumption on when levels can change.