### PR TITLE
Fix: Bazel Lint Errors and CI Workflow

### DIFF
--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -1,0 +1,44 @@
+name: Lint Bazel
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  buildifier:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - name: Run buildifier format
+            run: ./buildifier -r -mode=check -lint=off .
+          - name: Run buildifier lint
+            run: ./buildifier -r -lint=warn .
+    name: ${{ matrix.check.name }}
+    env:
+      BUILDIFIER_VERSION: v8.2.1
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v5
+
+      - name: Cache buildifier
+        id: cache-buildifier
+        uses: actions/cache@v4
+        with:
+          path: ./buildifier
+          key: ${{ runner.os }}-buildifier-${{ env.BUILDIFIER_VERSION }}
+
+      - name: Download buildifier
+        if: steps.cache-buildifier.outputs.cache-hit != 'true'
+        run: |
+          wget https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier-linux-amd64 -O buildifier
+          chmod +x buildifier
+
+      - name: ${{ matrix.check.name }}
+        run: ${{ matrix.check.run }}

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025, The OpenROAD Authors
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_hdl//dependency_support/com_github_westes_flex:flex.bzl", "genlex")
 load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
 load("//bazel:tcl_encode_sta.bzl", "tcl_encode_sta")
@@ -302,7 +304,6 @@ cc_library(
     name = "opensta_lib",
     srcs = parser_cc + parser_headers + glob(
         include = [
-            "app/StaMain.cc",
             "dcalc/*.cc",
             "dcalc/*.hh",
             "graph/*.cc",
@@ -333,6 +334,7 @@ cc_library(
             "util/Machine*.cc",
         ],
     ) + [
+        "app/StaMain.cc",
         "util/Machine.cc",
         ":StaConfig",
     ],


### PR DESCRIPTION
This PR resolves all `buildifier` linting errors in the `BUILD` file and introduces a new GitHub Actions workflow to automate Bazel linting checks.

**Changes:**

*   Corrected `load` statements for `cc_binary` and `cc_library`.
*   Fixed `constant-glob` warning for `app/StaMain.cc`.
*   Added a `buildifier` workflow in `.github/workflows/buildifier.yaml` to enforce linting on future pull requests.