### PR TITLE
Use same location for StaConfig.hh output as in cmake.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -177,8 +177,9 @@ tcl_encode_sta(
 genrule(
     name = "StaConfig",
     srcs = [],
-    outs = ["util/StaConfig.hh"],
+    outs = ["include/sta/StaConfig.hh"],
     cmd = """echo -e '
+    #pragma once
     #define STA_VERSION "2.7.0"
     #define STA_GIT_SHA1 "f21d4a3878e2531e3af4930818d9b5968aad9416"
     #define SSTA 0


### PR DESCRIPTION
CMakeLists.txt:393 puts the output in include/sta/StaConfig.hh; do the same for bazel.