### PR TITLE
bazel/tcl: migrate from rules_hdl tcl to bazel BCR tcl version

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -296,7 +296,7 @@ cc_binary(
     deps = [
         ":opensta_lib",
         "@rules_cc//cc/runfiles",
-        "@tk_tcl//:tcl",
+        "@tcl_lang//:tcl",
     ],
 )
 
@@ -397,7 +397,7 @@ cc_library(
         "@eigen",
         "@openmp",
         "@rules_flex//flex:current_flex_toolchain",
-        "@tk_tcl//:tcl",
+        "@tcl_lang//:tcl",
         "@zlib",
     ],
 )


### PR DESCRIPTION
The tcl version in the bazel central registry supports MacOS and it can be used via MODULES.bazel instead of WORKSPACE.