### PR TITLE
Fix building on MacOS by addding  MachineApple.cc to textual_hdrs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -390,7 +390,7 @@ cc_library(
         "util",
         "verilog",
     ],
-    textual_hdrs = ["util/MachineLinux.cc"],
+    textual_hdrs = ["util/MachineLinux.cc", "util/MachineApple.cc"],
     visibility = ["//:__subpackages__"],
     deps = [
         "@cudd",


### PR DESCRIPTION
Related [issue](https://github.com/The-OpenROAD-Project/OpenROAD/issues/9529)