### PR TITLE
bazel/macos: Changed bazel BUILD file to have MachineApple.cc for Macos build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -390,7 +390,10 @@ cc_library(
         "util",
         "verilog",
     ],
-    textual_hdrs = ["util/MachineLinux.cc"],
+    textual_hdrs = select({
+        "@platforms//os:osx": ["util/MachineApple.cc"],
+        "//conditions:default": ["util/MachineLinux.cc"],
+    }),
     visibility = ["//:__subpackages__"],
     deps = [
         "@cudd",


### PR DESCRIPTION
I changed the BUILD file for bazel to support MacOS bazel build.