### PR TITLE
sdc: add clockGroupsNameMap

### DIFF
--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -1035,6 +1035,10 @@ public:
   bool isPathDelayInternalTo(const Pin *pin) const;
   bool isPathDelayInternalToBreak(const Pin *pin) const;
   const ExceptionPathSet &exceptions() const { return exceptions_; }
+  const ClockGroupsNameMap &clockGroupsNameMap() const
+  {
+    return clk_groups_name_map_;
+  }
   void deleteExceptions();
   void deleteException(ExceptionPath *exception);
   void recordException(ExceptionPath *exception);


### PR DESCRIPTION
Adds access `clk_groups_name_map_`.