### PR TITLE
expose libertybuilder for 3DIC support in dbsta

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -362,6 +362,8 @@ cc_library(
         "search/ReportPath.hh",
         "spice/WritePathSpice.hh",
         "dcalc/PrimaDelayCalc.hh",
+        # Needed by src/dbSta to synthesize LibertyCells programmatically.
+        "liberty/LibertyBuilder.hh",
     ],
     copts = [
         "-Wno-error",


### PR DESCRIPTION
Added liberty/LibertyBuilder.hh to OpenSTA's public hdrs list in src/sta/BUILD. Same section already exports other private headers needed by SWIG; mine joins that block with a comment explaining why dbSta needs it.
Needed by dbSta for 3DIC support https://github.com/The-OpenROAD-Project/OpenROAD/pull/10417