### PR TITLE
Explicitly mark dependencies as keep for bracket-headers used.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -396,11 +396,11 @@ cc_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "@cudd",
-        "@eigen",
-        "@openmp",
+        "@eigen",  # keep. Is used, but with <>-includes
+        "@openmp",  # keep. Is needed ? Nobody includes omp.h
         "@rules_flex//flex:current_flex_toolchain",
-        "@tcl_lang//:tcl",
-        "@zlib",
+        "@tcl_lang//:tcl",  # keep. Is used, but with <>-includes
+        "@zlib",  # keep. Is used, but with <>-includes
     ],
 )
 


### PR DESCRIPTION
This project uses bracket includes for dependencies that are actually vendored via the MODULE.bazel.
So they should use `"zlib.h"`, `"tcl.h"` etc, but here they use `<zlib.h>`, `<tcl.h>` which makes them look like system headers.

They are meant to be using the vendored headers, to explicitly tell build_cleaner (`bant`) that the dependencies should be kept. (ideally, we fix the includes, but since this is a fork, this might be harder to maintain).

Also keeps `@openmp` for now, but see #364 if this is actually needed.