### PR TITLE
Sta latest 0528

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,18 +125,16 @@ if { ![catch {package require tclreadline}] } {
 The Zlib library is an optional.  If CMake finds libz, OpenSTA can
 read Liberty, Verilog, SDF, SPF, and SPEF files compressed with gzip.
 
-CUDD is a binary decision diageram (BDD) package that is used to
-improve conditional timing arc handling, constant propagation, power
-activity propagation and spice netlist generation.
+[CUDD](https://github.com/cuddorg/cudd) is a binary decision diagram (BDD)
+package that is used to improve conditional timing arc handling, constant
+propagation, power activity propagation and spice netlist generation.
 
-CUDD is available
-[here](https://github.com/davidkebo/cudd/blob/main/cudd_versions/cudd-3.0.0.tar.gz).
-
-Unpack and build CUDD.
+Download and build CUDD:
 
 ```
-tar xvfz cudd-3.0.0.tar.gz
-cd cudd-3.0.0
+git clone https://github.com/cuddorg/cudd.git
+cd cudd
+git checkout 3.0.0
 ./configure
 make
 ```

--- a/cmake/FindTCL.cmake
+++ b/cmake/FindTCL.cmake
@@ -34,6 +34,7 @@ if (NOT TCL_LIB_PATHS)
   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(TCL_LIB_PATHS
       #/opt/homebrew/Cellar/tcl-tk/9.0.3/lib
+      /opt/homebrew/Cellar/tcl-tk@8/8.6.18/lib
       /opt/homebrew/Cellar/tcl-tk@8/8.6.17/lib
       /opt/homebrew/Cellar/tcl-tk@8/8.6.16/lib
       /opt/homebrew/opt/tcl-tk/lib /usr/local/lib)

--- a/include/sta/Hash.hh
+++ b/include/sta/Hash.hh
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <string_view>
 
 namespace sta {
@@ -58,13 +57,5 @@ nextMersenne(size_t n)
 // Sadly necessary until c++ std::hash works for char *.
 size_t
 hashString(std::string_view str);
-
-// Pointer hashing is strongly discouraged because it causes results to change
-// from run to run. Use Network::id functions instead.
-#if __WORDSIZE == 64
-  #define hashPtr(ptr) (reinterpret_cast<intptr_t>(ptr) >> 3)
-#else
-  #define hashPtr(ptr) (reinterpret_cast<intptr_t>(ptr) >> 2)
-#endif
 
 } // namespace sta

--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -899,6 +899,10 @@ public:
                         const MinMaxAll *min_max,
                         const RiseFallBoth *rf,
                         float slew);
+  void unsetAnnotatedSlew(Vertex *vertex,
+                          const Scene *scene,
+                          const MinMaxAll *min_max,
+                          const RiseFallBoth *rf);
   void writeSdf(std::string_view filename,
                 const Scene *scene,
                 char divider,

--- a/search/ReportPath.cc
+++ b/search/ReportPath.cc
@@ -3252,9 +3252,9 @@ ReportPath::reportLine(std::string_view what,
           reportFieldBlank(field, line);
       }
       else if (field == field_case_)
-        line += line_case;
+        reportField(line_case, field, line);
       else if (field->getValue())
-        line += field->value(path, this);
+        reportField(field->value(path, this), field, line);
 
       first_field = false;
     }

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -3875,7 +3875,6 @@ Sta::setAnnotatedSlew(Vertex *vertex,
                       const RiseFallBoth *rf,
                       float slew)
 {
-  ensureGraph();
   for (const MinMax *mm : min_max->range()) {
     DcalcAPIndex ap_index = scene->dcalcAnalysisPtIndex(mm);
     for (const RiseFall *rf1 : rf->range()) {
@@ -3885,6 +3884,24 @@ Sta::setAnnotatedSlew(Vertex *vertex,
     }
   }
   graph_delay_calc_->delayInvalid(vertex);
+}
+
+void
+Sta::unsetAnnotatedSlew(Vertex *vertex,
+                        const Scene *scene,
+                        const MinMaxAll *min_max,
+                        const RiseFallBoth *rf)
+{
+  for (const MinMax *mm : min_max->range()) {
+    DcalcAPIndex ap_index = scene->dcalcAnalysisPtIndex(mm);
+    for (const RiseFall *rf1 : rf->range()) {
+      vertex->setSlewAnnotated(false, rf1, ap_index);
+    }
+  }
+  if (vertex->isDriver(network_))
+    graph_delay_calc_->delayInvalid(vertex);
+  else
+    delaysInvalidFromFanin(vertex);
 }
 
 void

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -4291,8 +4291,15 @@ Parasitics *
 Sta::makeConcreteParasitics(std::string_view name,
                             std::string_view filename)
 {
+  // Free the prior entry to avoid leaking it on overwrite.
+  std::string key(name);
+  auto it = parasitics_name_map_.find(key);
+  if (it != parasitics_name_map_.end()) {
+    delete it->second;
+    parasitics_name_map_.erase(it);
+  }
   Parasitics *parasitics = new ConcreteParasitics(name, filename, this);
-  parasitics_name_map_[std::string(name)] = parasitics;
+  parasitics_name_map_[key] = parasitics;
   return parasitics;
 }
 

--- a/test/make_concrete_parasitics_leak.tcl
+++ b/test/make_concrete_parasitics_leak.tcl
@@ -1,0 +1,9 @@
+# Sta::makeConcreteParasitics map-overwrite leak repro.
+# Run under -fsanitize=address to verify no leak after the fix.
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+# 1st read_spef
+read_spef -min reg1_asap7.spef
+# 2nd read_spef
+read_spef -min reg1_asap7.spef

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -154,6 +154,7 @@ record_public_tests {
   liberty_ccsn
   liberty_float_as_str
   liberty_latch3
+  make_concrete_parasitics_leak
   package_require
   path_group_names
   power_json


### PR DESCRIPTION
Latest upstream OpenSTA

Note that hashPtr was removed from sta upstream (commit ffd54f38 "rm hashPtr"). 
So we need fix two OpenROAD callers: est/EstimateParasitics.h:47 and rsz/Resizer.hh:88 to build OpenROAD succesfully.

