### PR TITLE
We're not using runfiles anymore, don't use associated macro define.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -280,6 +280,7 @@ cc_binary(
         "-Wno-unused-parameter",
         "-Wno-sign-compare",
     ],
+    defines = ["BAZEL_BUILD"],
     features = ["-use_header_modules"],
     includes = [
         "",
@@ -293,7 +294,6 @@ cc_binary(
         ":opensta_lib",
         "//:tcl_readline_setup",
         "//bazel:tcl_library_init",
-        "@rules_cc//cc/runfiles",
         "@tcl_lang//:tcl",
     ],
 )

--- a/app/Main.cc
+++ b/app/Main.cc
@@ -31,7 +31,7 @@
 #include <string_view>
 #include <tcl.h>
 
-#ifdef BAZEL_CURRENT_REPOSITORY
+#ifdef BAZEL_BUILD
   #include "bazel/tcl_library_init.h"
   #include "src/tcl_readline_setup.h"
 #endif
@@ -115,7 +115,7 @@ staTclAppInit(int argc,
               std::string_view init_filename,
               Tcl_Interp *interp)
 {
-#ifdef BAZEL_CURRENT_REPOSITORY
+#ifdef BAZEL_BUILD
     if (in_bazel::SetupTclEnvironment(interp) == TCL_ERROR) {
       return TCL_ERROR;
     }
@@ -126,7 +126,7 @@ staTclAppInit(int argc,
     return TCL_ERROR;
 
   bool has_readline = false;
-#ifdef BAZEL_CURRENT_REPOSITORY
+#ifdef BAZEL_BUILD
   has_readline = (ord::SetupTclReadlineLibrary(interp) == TCL_OK);
 #endif
 #if TCL_READLINE


### PR DESCRIPTION
We used to use runfiles to work with tcl dependencies. Since we don't need that anymore, just add a regular `BAZEL_BUILD` define to choose the behavior in the bazel build and remove the unneeded dependency.