### PR TITLE
LibertyReader: guard null FuncExpr/members on malformed Liberty 

### DIFF
--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -1159,6 +1159,10 @@ LibertyReader::makeBundlePort(LibertyCell *cell,
     debugPrint(debug_, "liberty", 1, " bundle {}", bundle_name);
     
     const LibertyComplexAttr *member_attr = bundle_group->findComplexAttr("members");
+    if (member_attr == nullptr) {
+      warn(1315, bundle_group, "bundle {} missing members.", bundle_name);
+      return;
+    }
     ConcretePortSeq *members = new ConcretePortSeq;
     for (const LibertyAttrValue *member_value : member_attr->values()) {
       if (member_value->isString()) {
@@ -1628,7 +1632,7 @@ LibertyReader::makePortFuncs(LibertyCell *cell,
       FuncExpr *func_expr = parseFunc(func, "function", cell, func_attr->line());
       for (LibertyPort *port : ports) {
         port->setFunction(func_expr);
-        if (func_expr->checkSize(port)) {
+        if (func_expr && func_expr->checkSize(port)) {
           warn(1195, func_attr->line(),
                   "port {} function size does not match port size.",
                   port->name());
@@ -1644,11 +1648,13 @@ LibertyReader::makePortFuncs(LibertyCell *cell,
       FuncExpr *tri_disable_expr = parseFunc(tri_disable,
                                              "three_state", cell,
                                              tri_attr->line());
-      FuncExpr *tri_enable_expr = tri_disable_expr->invert();
-      for (LibertyPort *port : ports) {
-        port->setTristateEnable(tri_enable_expr);
-        if (port->direction() == PortDirection::output())
-          port->setDirection(PortDirection::tristate());
+      if (tri_disable_expr) {
+        FuncExpr *tri_enable_expr = tri_disable_expr->invert();
+        for (LibertyPort *port : ports) {
+          port->setTristateEnable(tri_enable_expr);
+          if (port->direction() == PortDirection::output())
+            port->setDirection(PortDirection::tristate());
+        }
       }
     }
   }

--- a/liberty/test/CMakeLists.txt
+++ b/liberty/test/CMakeLists.txt
@@ -13,6 +13,7 @@ sta_module_tests("liberty"
     equiv_map_libs
     func_expr
     leakage_power_deep
+    malformed_ports
     multi_corner
     multi_lib_equiv
     opcond_scale

--- a/liberty/test/liberty_malformed_ports.lib
+++ b/liberty/test/liberty_malformed_ports.lib
@@ -1,0 +1,26 @@
+/* Liberty with malformed port attributes, used by liberty_malformed_ports.tcl.
+   Each cell exercises a LibertyReader code path that previously dereferenced a
+   null FuncExpr / null members attribute and crashed (SIGSEGV). After the fix
+   the reader emits a warning and continues. */
+library (malformed_ports) {
+  delay_model : table_lookup;
+
+  /* "function" references an undeclared pin, so parseFunc() returns null. */
+  cell (BAD_FUNC) {
+    pin (A) { direction : input; }
+    pin (Z) { direction : output; function : "A & NOPIN"; }
+  }
+
+  /* "three_state" references an undeclared pin, so parseFunc() returns null. */
+  cell (BAD_TRI) {
+    pin (A) { direction : input; }
+    pin (EN) { direction : input; }
+    pin (Z) { direction : output; three_state : "BADPIN"; function : "A"; }
+  }
+
+  /* "bundle" group with no "members" attribute. */
+  cell (BAD_BUNDLE) {
+    pin (A) { direction : input; }
+    bundle (B) { direction : output; }
+  }
+}

--- a/liberty/test/liberty_malformed_ports.ok
+++ b/liberty/test/liberty_malformed_ports.ok
@@ -1,0 +1,4 @@
+Warning 1130: liberty_malformed_ports.lib line 11, function references unknown port NOPIN.
+Warning 1130: liberty_malformed_ports.lib line 18, three_state references unknown port BADPIN.
+Warning 1315: liberty_malformed_ports.lib line 24, bundle B missing members.
+read_liberty completed, cells loaded: 3

--- a/liberty/test/liberty_malformed_ports.tcl
+++ b/liberty/test/liberty_malformed_ports.tcl
@@ -1,0 +1,8 @@
+# Malformed port attributes must produce a clean warning, not crash the reader.
+# Regression for LibertyReader null-dereferences:
+#   - makePortFuncs(): "function" expression that parses to null (undeclared pin)
+#   - makePortFuncs(): "three_state" expression that parses to null
+#   - makeBundlePort(): "bundle" group with no "members" attribute
+# Before the fix each of these dereferenced a null pointer and crashed (SIGSEGV).
+read_liberty liberty_malformed_ports.lib
+puts "read_liberty completed, cells loaded: [llength [get_lib_cells malformed_ports/*]]"


### PR DESCRIPTION
Fix three null-dereference crashes in LibertyReader on malformed Liberty

Reading a Liberty file with certain malformed port attributes crashes OpenSTA
with a SIGSEGV. Three sites in `LibertyReader` dereference a pointer that can
legitimately be null on malformed input. This adds the missing null guards
(matching the existing guarded sibling path) so the reader emits a warning and
continues, plus a focused regression test.

## reoroduce via this

A few lines of Liberty + `read_liberty`:

1. `function` references an undeclared pin (e.g. a typo):
   `pin (Z) { direction : output; function : "A & NOPIN"; }`
2. `three_state` references an undeclared pin:
   `pin (Z) { direction : output; three_state : "BADPIN"; function : "A"; }`
3. `bundle` group with no `members`:
   `bundle (B) { direction : output; }`

## Root cause

- `LibertyReader::makePortFuncs()` calls `parseFunc()` for `function` and
  `three_state`. `parseFunc()` returns `nullptr` for an expression that parses
  but references an unknown port (`LibExprReader::makeFuncExprPort` warns and
  returns null). The results were dereferenced unconditionally
  (`func_expr->checkSize(port)`, `tri_disable_expr->invert()`).
- `LibertyReader::makeBundlePort()` calls `findComplexAttr("members")`, which
  returns `nullptr` when the attribute is absent, then dereferences it in the
  range-for (`member_attr->values()`) and leaks the allocated `ConcretePortSeq`.

The correct pattern already exists in the same file: `makeSeqFunc()` guards with
`if (expr && expr->checkSize(size))`. These three sites simply missed it.

## Fix

- `function`: `if (func_expr && func_expr->checkSize(port))` (mirrors makeSeqFunc).
- `three_state`: wrap the tristate handling in `if (tri_disable_expr) { ... }`.
- `bundle`: if `members` is absent, `warn(1315, ...) "bundle <name> missing
  members."` and return (also avoids the leak).

Valid Liberty is unaffected — the guarded expressions are non-null there. On
malformed input the reader now warns and continues; the cell loads minus the
bad attribute.

## Tests

New regression `liberty/test/liberty_malformed_ports.{lib,tcl}` (+ golden `.ok`),
registered in `liberty/test/CMakeLists.txt`. One `read_liberty` exercises all
three paths; the golden pins the warnings and confirms recovery


## Verification
- All three reproducers now exit 0 instead of SIGSEGV (exit 139).
- `ctest -R tcl.liberty`: 33/33 pass (32 existing + the new test).
- Full `ctest` suite: 6083/6083 pass, zero regressions.
## Files changed
- `liberty/LibertyReader.cc` — three null guards (+ new warning id 1315)
- `liberty/test/liberty_malformed_ports.lib` — new (test input)
- `liberty/test/liberty_malformed_ports.tcl` — new (test driver)
- `liberty/test/liberty_malformed_ports.ok` — new (golden)
- `liberty/test/CMakeLists.txt` — register the new test
