### PR TITLE
Fix heap-use-after-free in PrimaDelayCalc copy constructor

### DIFF
--- a/dcalc/PrimaDelayCalc.cc
+++ b/dcalc/PrimaDelayCalc.cc
@@ -65,7 +65,11 @@ PrimaDelayCalc::PrimaDelayCalc(StaState *sta) :
 PrimaDelayCalc::PrimaDelayCalc(const PrimaDelayCalc &dcalc) :
   DelayCalcBase(dcalc),
   pin_node_map_(network_),
-  node_index_map_(dcalc.node_index_map_),
+  // node_index_map_ is intentionally not copied. Its keys are raw
+  // ParasiticNode* whose pointees may already be freed when this copy is made
+  // (parasitic networks are rebuilt during repair), and copying the map would
+  // dereference them via the ParasiticNodeLess comparator. It is transient
+  // state rebuilt by findNodeCount() before any read.
   prima_order_(dcalc.prima_order_),
   watch_pin_values_(network_),
   table_dcalc_(makeDmpCeffElmoreDelayCalc(this))


### PR DESCRIPTION
The copy constructor copied node_index_map_, a
std::map<const ParasiticNode*, size_t, ParasiticNodeLess>. Copying the map reconstructs its red-black tree, which invokes the ParasiticNodeLess comparator and dereferences the ParasiticNode* keys.

When a delay calculator is cloned for parallel delay calculation (GraphDelayCalc::findDelays -> FindVertexDelays -> ArcDelayCalc::copy), the source map can hold pointers to ParasiticNodes that were already freed because the net's parasitic network was rebuilt (e.g. during resizer repair). Dereferencing those freed keys is a heap-use-after-free.

node_index_map_ is transient state: findNodeCount() clears and rebuilds it from the current parasitic network before any read, and the primary constructor leaves it default-constructed. Copying it is therefore both unnecessary and the sole source of the dangling-pointer dereference, so leave it default-constructed in the copy constructor as well.