### PR TITLE
search/parasitics: AOCV depth-based derate hook + SI-window coupling-cap setter

### DIFF
--- a/include/sta/Parasitics.hh
+++ b/include/sta/Parasitics.hh
@@ -201,6 +201,12 @@ public:
                              ParasiticNode *node2) = 0;
   virtual uint32_t id(const ParasiticCapacitor *capacitor) const = 0;
   virtual float value(const ParasiticCapacitor *capacitor) const = 0;
+  // OpenROAD-fork: SI-window -- set a single (coupling) capacitor's value.
+  // Used by the OpenROAD timing-window aware coupling derate to scale the
+  // coupling caps of non-overlapping aggressors. Default no-op preserves
+  // behavior for any Parasitics implementation that does not support it.
+  virtual void setCapacitorValue(ParasiticCapacitor * /* capacitor */,
+                                 float /* value */) {}
   virtual ParasiticNode *node1(const ParasiticCapacitor *capacitor) const = 0;
   virtual ParasiticNode *node2(const ParasiticCapacitor *capacitor) const = 0;
   virtual ParasiticNode *otherNode(const ParasiticCapacitor *capacitor,

--- a/include/sta/Search.hh
+++ b/include/sta/Search.hh
@@ -72,6 +72,27 @@ using WorstSlacksSeq = std::vector<WorstSlacks>;
 using DelayDblSeq = std::vector<DelayDbl>;
 using ExceptionPathSeq = std::vector<ExceptionPath*>;
 
+// OpenROAD-fork: AOCV
+// Abstract depth->derate hook for AOCV-style depth-dependent OCV derating
+// during forward arrival propagation. OpenSTA core does not depend on the
+// concrete dbSta AocvDerateTable; the implementation lives in OpenROAD
+// (src/dbSta) and is installed on Search via setAocvDepthDerate(). When no hook
+// is installed (the default), timing propagation is byte-identical to upstream.
+class AocvDepthDerate
+{
+ public:
+  virtual ~AocvDepthDerate() = default;
+  // depth is the number of combinational data-path stages traversed so far
+  // (including the arc being derated).
+  virtual float lateDerate(int depth) const = 0;
+  virtual float earlyDerate(int depth) const = 0;
+  // When false for a side, deratedDelayData keeps the flat SDC derate for that
+  // side instead of overriding it (e.g. a late-only table must not silently
+  // zero out a user's set_timing_derate -early on the min path).
+  virtual bool lateActive() const = 0;
+  virtual bool earlyActive() const = 0;
+};
+
 class Search : public StaState
 {
 public:
@@ -349,6 +370,24 @@ public:
                         const MinMax *min_max,
                         DcalcAPIndex dcalc_ap,
                         const Sdc *sdc);
+  // OpenROAD-fork: AOCV
+  // Data-path arc delay that, when an AocvDepthDerate hook is installed, applies
+  // a depth-dependent derate (selected by the combinational depth of from_path)
+  // instead of the flat SDC derate. With no hook installed this forwards
+  // verbatim to deratedDelay(...) so the result is byte-identical to upstream.
+  ArcDelay deratedDelayData(const Path *from_path,
+                            const Vertex *from_vertex,
+                            const TimingArc *arc,
+                            const Edge *edge,
+                            const MinMax *min_max,
+                            DcalcAPIndex dcalc_ap,
+                            const Sdc *sdc);
+  // Install (or clear, with nullptr) the AOCV depth-derate hook. Not owned.
+  void setAocvDepthDerate(const AocvDepthDerate *derate);
+  const AocvDepthDerate *aocvDepthDerate() const { return aocv_depth_derate_; }
+  // Combinational depth of the data arrival reaching from_path's vertex,
+  // including the arc currently being applied (so the first data stage == 1).
+  int aocvDataDepth(const Path *from_path) const;
 
   TagGroup *tagGroup(const Vertex *vertex) const;
   TagGroup *tagGroup(TagGroupIndex index) const;
@@ -670,6 +709,11 @@ protected:
   VisitPathEnds *visit_path_ends_;
   GatedClk *gated_clk_;
   CheckCrpr *check_crpr_;
+
+  // OpenROAD-fork: AOCV
+  // Optional depth-dependent OCV derate hook. nullptr (the default) means the
+  // feature is OFF and propagation is byte-identical to upstream. Not owned.
+  const AocvDepthDerate *aocv_depth_derate_{nullptr};
 };
 
 // Eval across latch D->Q edges.

--- a/parasitics/ConcreteParasitics.cc
+++ b/parasitics/ConcreteParasitics.cc
@@ -1414,6 +1414,16 @@ ConcreteParasitics::value(const ParasiticCapacitor *capacitor) const
   return ccapacitor->value();
 }
 
+// OpenROAD-fork: SI-window
+void
+ConcreteParasitics::setCapacitorValue(ParasiticCapacitor *capacitor,
+                                      float value)
+{
+  ConcreteParasiticCapacitor *ccapacitor =
+    static_cast<ConcreteParasiticCapacitor*>(capacitor);
+  ccapacitor->setValue(value);
+}
+
 ParasiticNode *
 ConcreteParasitics::node1(const ParasiticCapacitor *capacitor) const
 {

--- a/parasitics/ConcreteParasitics.cc
+++ b/parasitics/ConcreteParasitics.cc
@@ -1419,6 +1419,8 @@ void
 ConcreteParasitics::setCapacitorValue(ParasiticCapacitor *capacitor,
                                       float value)
 {
+  if (capacitor == nullptr)
+    return;
   ConcreteParasiticCapacitor *ccapacitor =
     static_cast<ConcreteParasiticCapacitor*>(capacitor);
   ccapacitor->setValue(value);

--- a/parasitics/ConcreteParasitics.hh
+++ b/parasitics/ConcreteParasitics.hh
@@ -170,6 +170,8 @@ public:
                      ParasiticNode *node2) override;
   uint32_t id(const ParasiticCapacitor *capacitor) const override;
   float value(const ParasiticCapacitor *capacitor) const override;
+  // OpenROAD-fork: SI-window
+  void setCapacitorValue(ParasiticCapacitor *capacitor, float value) override;
   ParasiticNode *node1(const ParasiticCapacitor *capacitor) const override;
   ParasiticNode *node2(const ParasiticCapacitor *capacitor) const override;
 

--- a/parasitics/ConcreteParasiticsPvt.hh
+++ b/parasitics/ConcreteParasiticsPvt.hh
@@ -303,6 +303,9 @@ public:
                           ConcreteParasiticNode *node2);
   uint32_t id() const { return id_; }
   float value() const { return value_; }
+  // OpenROAD-fork: SI-window -- per-device value override used by the
+  // OpenROAD window-aware coupling derate. Not used by stock OpenSTA.
+  void setValue(float value) { value_ = value; }
   ConcreteParasiticNode *node1() const { return node1_; }
   ConcreteParasiticNode *node2() const { return node2_; }
   void replaceNode(ConcreteParasiticNode *from_node,

--- a/search/Search.cc
+++ b/search/Search.cc
@@ -2216,8 +2216,10 @@ PathVisitor::visitFromPath(const Pin *from_pin,
   else {
     if (!(sdc->isPathDelayInternalFromBreak(to_pin)
           || sdc->isPathDelayInternalToBreak(from_pin))) {
-      arc_delay = search_->deratedDelay(from_vertex, arc, edge, false,
-                                        min_max, dcalc_ap, sdc);
+      // OpenROAD-fork: AOCV -- depth-dependent derate when a hook is installed;
+      // byte-identical to deratedDelay(... false ...) when it is not.
+      arc_delay = search_->deratedDelayData(from_path, from_vertex, arc, edge,
+                                            min_max, dcalc_ap, sdc);
       if (!delayInf(arc_delay, this)) {
         to_arrival = delaySum(from_arrival, arc_delay, this);
         to_tag = search_->thruTag(from_tag, edge, to_rf, tag_cache_);
@@ -3022,6 +3024,66 @@ Search::deratedDelay(const Vertex *from_vertex,
   float derate = timingDerate(from_vertex, arc, edge, is_clk, sdc, min_max);
   const ArcDelay &delay = graph_->arcDelay(edge, arc, dcalc_ap);
   return delayProduct(delay, derate, this);;
+}
+
+// OpenROAD-fork: AOCV
+void
+Search::setAocvDepthDerate(const AocvDepthDerate *derate)
+{
+  aocv_depth_derate_ = derate;
+}
+
+// OpenROAD-fork: AOCV
+// Count combinational data-path stages on from_path's prev chain, plus 1 for
+// the arc currently being applied. The prev chain is complete here because the
+// forward BFS commits prev-path pointers in topological level order before a
+// vertex's own paths are extended.
+int
+Search::aocvDataDepth(const Path *from_path) const
+{
+  int depth = 1;  // the arc about to be derated is the next stage
+  const Path *p = from_path;
+  while (p) {
+    const TimingArc *arc = p->prevArc(this);
+    if (arc && arc->role() == TimingRole::combinational())
+      depth++;
+    p = p->prevPath();
+  }
+  return depth;
+}
+
+// OpenROAD-fork: AOCV
+ArcDelay
+Search::deratedDelayData(const Path *from_path,
+                         const Vertex *from_vertex,
+                         const TimingArc *arc,
+                         const Edge *edge,
+                         const MinMax *min_max,
+                         DcalcAPIndex dcalc_ap,
+                         const Sdc *sdc)
+{
+  // Feature OFF: identical to the original data-path derate call.
+  if (aocv_depth_derate_ == nullptr)
+    return deratedDelay(from_vertex, arc, edge, false, min_max, dcalc_ap, sdc);
+
+  // Only depth-derate combinational cell arcs; everything else keeps the flat
+  // SDC derate (matches the report-only slice and avoids perturbing clock /
+  // CRPR / check arcs).
+  if (edge->role() != TimingRole::combinational())
+    return deratedDelay(from_vertex, arc, edge, false, min_max, dcalc_ap, sdc);
+
+  // If the table has no entries for this side (late/early), keep the flat SDC
+  // derate for that side rather than silently overriding it with 1.0.
+  const bool is_late = (min_max == MinMax::max());
+  if (is_late ? !aocv_depth_derate_->lateActive()
+              : !aocv_depth_derate_->earlyActive())
+    return deratedDelay(from_vertex, arc, edge, false, min_max, dcalc_ap, sdc);
+
+  const int depth = aocvDataDepth(from_path);
+  const float derate = is_late ? aocv_depth_derate_->lateDerate(depth)
+                               : aocv_depth_derate_->earlyDerate(depth);
+  const ArcDelay &delay = graph_->arcDelay(edge, arc, dcalc_ap);
+  return delayProduct(delay, derate, this);
 }
 
 float


### PR DESCRIPTION
## Summary

Two flag-gated, default-no-op OpenSTA hooks that let an external driver (OpenROAD dbSta/rcx) refine timing without changing stock OpenSTA behavior. With no hook installed, timing is byte-identical to upstream.

### 1. AOCV depth-based derate (`search/Search.{hh,cc}`)
Adds an abstract `AocvDepthDerate` hook and `Search::deratedDelayData` so the OCV derate applied to **data-path combinational arcs** during forward arrival propagation can be selected by the path's accumulated combinational depth instead of the flat SDC factor.

- When no hook is installed (the default), `deratedDelayData` forwards verbatim to `deratedDelay` → byte-identical to upstream.
- Only data-path combinational cell arcs are depth-derated; clock/reg/latch/check arcs keep the flat derate.
- Depth is the count of combinational arcs on the live `from_path` prev chain + 1.
- A `lateActive()`/`earlyActive()` per-side gate prevents a late-only table from silently zeroing a user's `set_timing_derate -early` on the min path.

### 2. SI-window per-coupling-capacitor value setter (`parasitics/*`)
Adds `Parasitics::setCapacitorValue` (default no-op) plus a `ConcreteParasitics` override / `ConcreteParasiticDevice::setValue`, so a timing-window-aware coupling derate can scale individual coupling caps. Only invoked from the external window path; stock OpenSTA behavior is unchanged.

## Testing
- Full OpenSTA ctest suite: 6083/6084 pass. The single failure (`tcl.power.vcd_detailed`) is a pre-existing last-digit floating-point rounding diff in the power module that fails identically on unmodified `master` (unrelated to this change).
- Derate / CRPR / multicorner / OCV-derate regressions all pass; timing is byte-identical with no hook installed.

## Notes
- `clang-format` intentionally not run on `src/sta/*` per project convention.
- Both hooks are additive and default-off; no behavior change for existing users.
