### PR TITLE
Remove duplicated list BUILD, derive one from the other

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -141,26 +141,19 @@ exports_files([
     "etc/TclEncode.tcl",
 ])
 
-exported_tcl = [
-    "tcl/Util.tcl",
-    "tcl/CmdUtil.tcl",
-    "tcl/CmdArgs.tcl",
-    "tcl/Property.tcl",
-    "tcl/Splash.tcl",
-    "tcl/Sta.tcl",
-    "sdc/Variables.tcl",
-    "sdc/Sdc.tcl",
-    "sdf/Sdf.tcl",
-    "search/Search.tcl",
-    "dcalc/DelayCalc.tcl",
-    "graph/Graph.tcl",
-    "liberty/Liberty.tcl",
-    "network/Network.tcl",
-    "network/NetworkEdit.tcl",
-    "parasitics/Parasitics.tcl",
-    "power/Power.tcl",
-    "spice/WriteSpice.tcl",
+# Files used only by the standalone OpenSTA shell. OpenROAD supplies its own
+# equivalents (Init via ord, Link/Verilog via dbSta), so they are excluded from
+# the set re-exported to dbSta.
+sta_only_tcl = [
+    "tcl/Init.tcl",
+    "network/Link.tcl",
+    "verilog/Verilog.tcl",
 ]
+
+# Re-exported to dbSta (and thus the OpenROAD binary). Derived from tcl_srcs so
+# a new command file added there automatically flows here unless explicitly
+# listed in sta_only_tcl. Single source of truth = tcl_srcs.
+exported_tcl = [f for f in tcl_srcs if f not in sta_only_tcl]
 
 filegroup(
     name = "tcl_scripts",


### PR DESCRIPTION
Long term maintainance for this fix: https://github.com/The-OpenROAD-Project/OpenSTA/pull/391

spice/WriteSpice.tcl was never added to the Tcl lists in src/sta/BUILD, though CMake has it in both its encode lists (my slip while pulling upstream). 
The SWIG glue  (WriteSpice.i) is listed, so the C++ compiled - the Tcl command wrappers just never get registered.

The deeper issue though: src/sta/BUILD maintains two Tcl lists by hand.
tcl_srcs : encoded into the standalone OpenSTA binary
exported_tcl : re-exported via dbSta into the OpenROAD binary

exported_tcl is just tcl_srcs minus a few files OpenROAD replaces (Init.tcl, network/Link.tcl, verilog/Verilog.tcl). 
Keeping two parallel lists in sync manually is kind of risky.

Potential fix for this long term- that will derive exported_tcl from tcl_srcs instead of maintaining it separately:

```
  sta_only_tcl = [
      "tcl/Init.tcl",
      "network/Link.tcl",
      "verilog/Verilog.tcl",
  ]
  exported_tcl = [f for f in tcl_srcs if f not in sta_only_tcl]
```

This makes tcl_srcs the single source of truth; any new command file flows to both binaries automatically unless explicitly excluded. 
Set is identical to today; only ordering changes, which is safe (the two build systems already use different orders and both work).