### PR TITLE
Chunk vertices in BFS parallel iteration for dynamic load balancing

### DIFF
--- a/include/sta/Bfs.hh
+++ b/include/sta/Bfs.hh
@@ -109,6 +109,15 @@ protected:
                   Level level);
   void findNext(Level to_level);
 
+  // ---- OpenROAD fork: BFS chunked dispatch (begin) ----
+  // Dispatch level_vertices to the worker pool in fixed-size chunks so
+  // idle threads pick up remaining work. Stop-gap until upstream BFS
+  // rework lands; on merge conflict take upstream and drop this.
+  void visitLevelChunked(VertexSeq &level_vertices,
+                         Level level,
+                         std::vector<VertexVisitor *> &visitors);
+  // ---- OpenROAD fork: BFS chunked dispatch (end) ----
+
   BfsIndex bfs_index_;
   Level level_min_;
   Level level_max_;

--- a/search/Bfs.cc
+++ b/search/Bfs.cc
@@ -182,25 +182,9 @@ BfsIterator::visitParallel(Level to_level,
             }
           }
           else {
-            size_t from = 0;
-            size_t chunk_size = vertex_count / thread_count;
-            BfsIndex bfs_index = bfs_index_;
-            for (size_t k = 0; k < thread_count; k++) {
-              // Last thread gets the left overs.
-              size_t to = (k == thread_count - 1) ? vertex_count : from + chunk_size;
-              dispatch_queue_->dispatch([=, this](size_t) {
-                for (size_t i = from; i < to; i++) {
-                  Vertex *vertex = level_vertices[i];
-                  if (vertex) {
-                    checkLevel(vertex, level);
-                    vertex->setBfsInQueue(bfs_index, false);
-                    visitors[k]->visit(vertex);
-                  }
-                }
-              });
-              from = to;
-            }
-            dispatch_queue_->finishTasks();
+            // ---- OpenROAD fork: BFS chunked dispatch (begin) ----
+            visitLevelChunked(level_vertices, level, visitors);
+            // ---- OpenROAD fork: BFS chunked dispatch (end) ----
           }
           level_vertices.clear();
           visit_count += vertex_count;
@@ -335,6 +319,39 @@ BfsIterator::findNext(Level to_level)
     incrLevel(first_level_);
   }
 }
+
+// ---- OpenROAD fork: BFS chunked dispatch (begin) ----
+void
+BfsIterator::visitLevelChunked(VertexSeq &level_vertices,
+                               Level level,
+                               std::vector<VertexVisitor *> &visitors)
+{
+  // Tasks read level_vertices in place and unlocked. This relies on
+  // visitors never enqueuing at the current level (they only enqueue
+  // fanout/fanin, which levelize places at a higher/lower level).
+  // Chunk size vs. runtime is U-shaped; 8 is the smallest size at the
+  // bottom of the curve.
+  constexpr size_t chunk_size = 8;
+  size_t vertex_count = level_vertices.size();
+  BfsIndex bfs_index = bfs_index_;
+  for (size_t from = 0; from < vertex_count; from += chunk_size) {
+    size_t to = (from + chunk_size < vertex_count) ? from + chunk_size : vertex_count;
+    dispatch_queue_->dispatch([this, &level_vertices, from, to, level,
+                               bfs_index, &visitors](int thread_id) {
+      VertexVisitor *thread_visitor = visitors[thread_id];
+      for (size_t i = from; i < to; i++) {
+        Vertex *vertex = level_vertices[i];
+        if (vertex) {
+          checkLevel(vertex, level);
+          vertex->setBfsInQueue(bfs_index, false);
+          thread_visitor->visit(vertex);
+        }
+      }
+    });
+  }
+  dispatch_queue_->finishTasks();
+}
+// ---- OpenROAD fork: BFS chunked dispatch (end) ----
 
 ////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Dispatch fixed-size chunks (8 vertices per task) in `BfsIterator::visitParallel` instead of one large contiguous slice per thread. Small chunks let threads that finish early pick up more work, and passing the level vertices to tasks by reference removes a per-task copy of the whole vector.

These changes can be thrown out in future upstream merges if there are conflicts.  This code is a minor improvement, meant to help out a bit until future upstream bfs improvements land.

### OpenSTA measurements
`report_checks` on a 32-core machine (min of 5 runs):
- gcd_sky130hd, 32 threads: 1845 us -> 1255 us (-32%)
- gcd_sky130hd, 8 threads: 1254 us -> 1117 us (-11%)
- aes_nangate45 (~17k inst): neutral at 8 and 32 threads
- Single-threaded code path is unchanged.

### ORFS validation (OpenROAD master, base vs. this branch, `NUM_CORES=8`)
Every stage `.odb` is byte-identical (sha1) between the two binaries; flow wall time is neutral.

| Design | base | branch |
|---|---|---|
| nangate45/gcd | 19 s | 19 s |
| nangate45/aes | 225 s | 223 s |
| nangate45/jpeg | 687 s | 678 s |
| sky130hd/aes | 979 s | 972 s |

### STA micro-benchmark on the final ORFS databases
| Design | Threads | base | branch | delta |
|---|---|---|---|---|
| nangate45/jpeg (~70k inst) | 8 | 238 ms | 211 ms | -11% |
| nangate45/jpeg | 32 | 256 ms | 253 ms | -1% |
| sky130hd/aes | 8 | 63 ms | 61 ms | -3% |
| sky130hd/aes | 32 | 75 ms | 74 ms | 0% |
