### PR TITLE
dcalc: Restore TwoPole parasitic reduction

### DIFF
--- a/dcalc/DmpDelayCalc.cc
+++ b/dcalc/DmpDelayCalc.cc
@@ -148,6 +148,11 @@ public:
                            const RiseFall *rf,
                            const Scene *scene,
                            const MinMax *min_max) override;
+  Parasitic *reduceParasitic(const Parasitic *parasitic_network,
+                             const Pin *drvr_pin,
+                             const RiseFall *rf,
+                             const Scene *scene,
+                             const MinMax *min_max) override;
   ArcDcalcResult inputPortDelay(const Pin *port_pin,
                                 float in_slew,
                                 const RiseFall *rf,
@@ -165,6 +170,8 @@ public:
                            const MinMax *min_max) override;
 
 protected:
+  using ArcDelayCalc::reduceParasitic;
+
   void loadDelaySlew(const Pin *load_pin,
                      double drvr_slew,
                      const RiseFall *rf,
@@ -255,6 +262,18 @@ DmpCeffTwoPoleDelayCalc::findParasitic(const Pin *drvr_pin,
                                              scene, min_max);
   }
   return parasitic;
+}
+
+Parasitic *
+DmpCeffTwoPoleDelayCalc::reduceParasitic(const Parasitic *parasitic_network,
+                                         const Pin *drvr_pin,
+                                         const RiseFall *rf,
+                                         const Scene *scene,
+                                         const MinMax *min_max)
+{
+  Parasitics *parasitics = scene->parasitics(min_max);
+  return parasitics->reduceToPiPoleResidue2(
+      parasitic_network, drvr_pin, rf, scene, min_max);
 }
 
 ArcDcalcResult


### PR DESCRIPTION
## Summary
- Restore calculator-specific PiPoleResidue2 reduction for dmp_ceff_two_pole.

## Problem
- The parasitics API migration removed the TwoPole reduced-type selector without adding the equivalent reduceParasitic override.
- Eager reduction therefore inherited LumpedCapDelayCalc and produced PiElmore, leaving TwoPole without pole/residue data after the detailed network was deleted.

## Solution
- Override DmpCeffTwoPoleDelayCalc::reduceParasitic to call reduceToPiPoleResidue2.
- Keep the inherited net-level reduction overload visible for generic callers.

## Impact
- TwoPole consumers receive the parasitic representation required by their load-delay model.
- DMP Ceff Elmore reduction remains unchanged.

## Testing
- Passed the OpenROAD dmp_ceff_dcalc_load_propagation Bazel regression with fresh placement estimation for Elmore, TwoPole, and Lambert-W.
- Passed OpenROAD build, Tcl lint/format, dbSta lint, clang-tidy, and direct CLI QA.

## Related
- https://github.com/The-OpenROAD-Project/OpenROAD/pull/11229