### PR TITLE
dcalc: Restore TwoPole parasitic reduction

### DIFF
--- a/dcalc/DmpDelayCalc.cc
+++ b/dcalc/DmpDelayCalc.cc
@@ -148,6 +148,11 @@ public:
                            const RiseFall *rf,
                            const Scene *scene,
                            const MinMax *min_max) override;
+  Parasitic *reduceParasitic(const Parasitic *parasitic_network,
+                             const Pin *drvr_pin,
+                             const RiseFall *rf,
+                             const Scene *scene,
+                             const MinMax *min_max) override;
   ArcDcalcResult inputPortDelay(const Pin *port_pin,
                                 float in_slew,
                                 const RiseFall *rf,
@@ -165,6 +170,8 @@ public:
                            const MinMax *min_max) override;
 
 protected:
+  using ArcDelayCalc::reduceParasitic;
+
   void loadDelaySlew(const Pin *load_pin,
                      double drvr_slew,
                      const RiseFall *rf,
@@ -255,6 +262,18 @@ DmpCeffTwoPoleDelayCalc::findParasitic(const Pin *drvr_pin,
                                              scene, min_max);
   }
   return parasitic;
+}
+
+Parasitic *
+DmpCeffTwoPoleDelayCalc::reduceParasitic(const Parasitic *parasitic_network,
+                                         const Pin *drvr_pin,
+                                         const RiseFall *rf,
+                                         const Scene *scene,
+                                         const MinMax *min_max)
+{
+  Parasitics *parasitics = scene->parasitics(min_max);
+  return parasitics->reduceToPiPoleResidue2(
+      parasitic_network, drvr_pin, rf, scene, min_max);
 }
 
 ArcDcalcResult

--- a/dcalc/test/cpp/TestDcalc.cc
+++ b/dcalc/test/cpp/TestDcalc.cc
@@ -3592,6 +3592,46 @@ TEST_F(DesignDcalcTest, DmpCeffTwoPoleWithParasitics) {
   EXPECT_GT(graph->vertexCount(), 0);
 }
 
+TEST_F(DesignDcalcTest, DmpCeffTwoPoleReducesToPiPoleResidue) {
+  ASSERT_TRUE(design_loaded_);
+  Scene *corner = sta_->cmdScene();
+  Network *network = sta_->network();
+  Instance *top = network->topInstance();
+  const bool read_spef = sta_->readSpef("spef",
+                                        "test/reg1_asap7.spef",
+                                        top,
+                                        corner,
+                                        MinMaxAll::all(),
+                                        false,
+                                        false,
+                                        1.0f,
+                                        false);
+  ASSERT_TRUE(read_spef);
+
+  Instance *u1 = network->findChild(top, "u1");
+  ASSERT_NE(u1, nullptr);
+  Pin *y_pin = network->findPin(u1, "Y");
+  ASSERT_NE(y_pin, nullptr);
+  const Net *net = network->net(y_pin);
+  ASSERT_NE(net, nullptr);
+
+  Parasitics *parasitics = sta_->findParasitics("spef");
+  ASSERT_NE(parasitics, nullptr);
+  Parasitic *network_parasitic = parasitics->findParasiticNetwork(net);
+  ASSERT_NE(network_parasitic, nullptr);
+
+  ArcDelayCalc *calc = makeDelayCalc("dmp_ceff_two_pole", sta_);
+  ASSERT_NE(calc, nullptr);
+  Parasitic *reduced = calc->reduceParasitic(network_parasitic,
+                                             y_pin,
+                                             RiseFall::rise(),
+                                             corner,
+                                             MinMax::max());
+  ASSERT_NE(reduced, nullptr);
+  EXPECT_TRUE(parasitics->isPiPoleResidue(reduced));
+  delete calc;
+}
+
 // R10_ DesignDcalcTest: reportDelayCalc exercises report path
 // Covers: GraphDelayCalc::reportDelayCalc
 TEST_F(DesignDcalcTest, ReportDelayCalcDmpElmore2) {


### PR DESCRIPTION
## Summary
- Restore calculator-specific PiPoleResidue2 reduction for dmp_ceff_two_pole.

## Problem
- The parasitics API migration removed the TwoPole reduced-type selector without adding the equivalent reduceParasitic override.
- Eager reduction therefore inherited LumpedCapDelayCalc and produced PiElmore, leaving TwoPole without pole/residue data after the detailed network was deleted.

## Solution
- Override DmpCeffTwoPoleDelayCalc::reduceParasitic to call reduceToPiPoleResidue2.
- Keep the inherited net-level reduction overload visible for generic callers.
- Add a regression that reduces a detailed SPEF network and verifies the result is PiPoleResidue.

## Impact
- TwoPole consumers receive the parasitic representation required by their load-delay model.
- DMP Ceff Elmore reduction remains unchanged.

## Related
- https://github.com/The-OpenROAD-Project-private/OpenROAD/pull/3699